### PR TITLE
Fix Overlap Tests in Biochemistry Incarnations

### DIFF
--- a/alchemist/alchemist-incarnation-biochemistry/src/test/java/it/unibo/alchemist/test/TestBioRect2DEnvironmentNoOverlap.java
+++ b/alchemist/alchemist-incarnation-biochemistry/src/test/java/it/unibo/alchemist/test/TestBioRect2DEnvironmentNoOverlap.java
@@ -40,7 +40,13 @@ import static org.junit.Assert.*;
  */
 public class TestBioRect2DEnvironmentNoOverlap {
 
-    private static final double DELTA = 1e-6;
+    /**
+     * The test seems to work for values of delta up to 2*10^(-8)
+     *
+     * As future changes in the core can vary the sensibility of floating point operations, leading to an undesired
+     * test failure, the value has been set to the next order of magnitude.
+     */
+    private static final double DELTA = 1e-7;
     private static final double BIG_CELL_DIAMETER = 30;
     private static final double MEDIUM_CELL_DIAMETER = 20;
     private static final double LITTLE_CELL_DIAMETER = 10;

--- a/alchemist/alchemist-incarnation-biochemistry/src/test/java/it/unibo/alchemist/test/TestBioRect2DEnvironmentNoOverlap.java
+++ b/alchemist/alchemist-incarnation-biochemistry/src/test/java/it/unibo/alchemist/test/TestBioRect2DEnvironmentNoOverlap.java
@@ -8,15 +8,11 @@
 package it.unibo.alchemist.test;
 
 import java.io.InputStream;
-import java.util.AbstractMap;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.math3.util.FastMath;
-import org.apache.commons.math3.util.Pair;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kaikikm.threadresloader.ResourceLoader;


### PR DESCRIPTION
Fixed test testNoOverlapInSimulation1 in TestBioRect2DEnvironmentNoOverlap.java, with minor refactoring of other tests due to internal changes.