### PR TITLE
Add ListOf variable

### DIFF
--- a/alchemist/alchemist-loading/src/main/kotlin/it/unibo/alchemist/loader/variables/ListOf.kt
+++ b/alchemist/alchemist-loading/src/main/kotlin/it/unibo/alchemist/loader/variables/ListOf.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2019, Danilo Pianini and contributors
+ * listed in the main project's alchemist/build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.loader.variables
+
+import com.google.common.collect.Streams
+import java.util.stream.Stream
+
+/**
+ * A list of arbitrary values.
+ */
+class ListOf<T : java.io.Serializable>(
+    private val default: T,
+    private vararg val values: T
+) : PrintableVariable<T>() {
+    override fun getDefault() = default
+
+    override fun stream(): Stream<T> = Streams.concat(Stream.of(default), Stream.of(*values))
+}

--- a/alchemist/alchemist-loading/src/test/kotlin/it/unibo/alchemist/test/TestListOfVariable.kt
+++ b/alchemist/alchemist-loading/src/test/kotlin/it/unibo/alchemist/test/TestListOfVariable.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2019, Danilo Pianini and contributors
+ * listed in the main project's alchemist/build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.test
+
+import io.kotlintest.matchers.maps.shouldContainKey
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import it.unibo.alchemist.loader.YamlLoader
+import java.util.stream.Collectors
+import org.apache.commons.codec.Resources
+
+class TestListOfVariable : StringSpec({
+    "Test YAML loading" {
+        val loader = YamlLoader(Resources.getInputStream("testListOfVariable.yml"))
+        loader.variables shouldContainKey "var"
+        loader.variables["var"]!!.stream().collect(Collectors.toList<Any>()) shouldBe listOf(1, 2, 3, 4)
+    }
+})

--- a/alchemist/alchemist-loading/src/test/resources/testListOfVariable.yml
+++ b/alchemist/alchemist-loading/src/test/resources/testListOfVariable.yml
@@ -1,0 +1,10 @@
+incarnation: sapere
+
+variables:
+  var:
+    type: ListOf
+    parameters: [1, 2, 3, 4]
+
+environment:
+  type: Continuous2DEnvironment
+  parameters: []


### PR DESCRIPTION
ListOf enables the following YAML syntax

```
variables:
  var:
    type: ListOf
    parameters: [1, 20, 30, 4000]
```