### PR TITLE
Fix Simulation documentation

### DIFF
--- a/alchemist/alchemist-interfaces/src/main/java/it/unibo/alchemist/core/interfaces/Simulation.java
+++ b/alchemist/alchemist-interfaces/src/main/java/it/unibo/alchemist/core/interfaces/Simulation.java
@@ -24,18 +24,15 @@ import it.unibo.alchemist.model.interfaces.Time;
  * This interface forces simulations to be independent threads, and make them
  * controllable from an external console.
  *
- * @param <T>
- *            Concentration type
- * @param <P>
- *            Position Type
+ * @param <T> Concentration type
+ * @param <P> Position Type
  */
 public interface Simulation<T, P extends Position<? extends P>> extends Runnable {
 
     /**
      * Adds an {@link OutputMonitor} to this simulation.
      *
-     * @param op
-     *            the OutputMonitor to add
+     * @param op the OutputMonitor to add
      */
     void addOutputMonitor(OutputMonitor<T, P> op);
 
@@ -90,17 +87,15 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
 
     /**
      * Executes a certain number of steps, then pauses it.
-     * 
-     * @param steps
-     *            the number of steps to execute
+     *
+     * @param steps the number of steps to execute
      */
     void goToStep(long steps);
 
     /**
      * Executes the simulation until the target time is reached, then pauses it.
-     * 
-     * @param t
-     *            the target time
+     *
+     * @param t the target time
      */
     void goToTime(Time t);
 
@@ -109,11 +104,9 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
      * nodes gets created during the simulation. This method provides dependency
      * and scheduling times re-computation for all the reactions interested by
      * such change.
-     * 
-     * @param node
-     *            the node
-     * @param n
-     *            the second node
+     *
+     * @param node the node
+     * @param n    the second node
      */
     void neighborAdded(Node<T> node, Node<T> n);
 
@@ -122,11 +115,9 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
      * nodes gets broken during the simulation. This method provides dependency
      * and scheduling times re-computation for all the reactions interested by
      * such change.
-     * 
-     * @param node
-     *            the node
-     * @param n
-     *            the second node
+     *
+     * @param node the node
+     * @param n    the second node
      */
     void neighborRemoved(Node<T> node, Node<T> n);
 
@@ -136,9 +127,8 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
      * can be consistently computed by the simulated environment). This method
      * provides dependency computation and is responsible of correctly
      * scheduling the Node's new reactions.
-     * 
-     * @param node
-     *            the freshly added node
+     *
+     * @param node the freshly added node
      * @throws IllegalMonitorStateException
      *             if the method gets called from a different thread than the
      *             simulation thread
@@ -151,9 +141,8 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
      * can be consistently computed by the simulated environment). This method
      * provides dependency computation and is responsible of correctly
      * scheduling the Node's reactions.
-     * 
-     * @param node
-     *            the node
+     *
+     * @param node the node
      */
     void nodeMoved(Node<T> node);
 
@@ -163,24 +152,22 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
      * computed (or can be consistently computed by the simulated environment).
      * This method provides dependency computation and is responsible of
      * correctly removing the Node's reactions from the scheduler.
-     * 
-     * @param node
-     *            the freshly removed node
-     * @param oldNeighborhood
-     *            the neighborhood of the node as it was before it was removed
-     *            (used to calculate reverse dependencies)
+     *
+     * @param node            the freshly removed node
+     * @param oldNeighborhood the neighborhood of the node as it was before it was removed
+     *                        (used to calculate reverse dependencies)
      */
     void nodeRemoved(Node<T> node, Neighborhood<T> oldNeighborhood);
 
     /**
-     * Sends a pause command to the simulation. There is no guarantee on when
-     * this command will be actually processed.
+     * Sends a pause command to the simulation.
+     * There is no guarantee on when this command will be actually processed.
      */
     void pause();
 
     /**
-     * Sends a play command to the simulation. There is no guarantee on when
-     * this command will be actually processed.
+     * Sends a play command to the simulation.
+     * There is no guarantee on when this command will be actually processed.
      */
     void play();
 
@@ -189,8 +176,7 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
      * {@link OutputMonitor} was not among those already added, this method does
      * nothing.
      *
-     * @param op
-     *            the OutputMonitor to add
+     * @param op the OutputMonitor to add
      */
     void removeOutputMonitor(OutputMonitor<T, P> op);
 
@@ -200,30 +186,26 @@ public interface Simulation<T, P extends Position<? extends P>> extends Runnable
      * being changed while the requested operation is being executed). An
      * exception thrown by the passed runnable will make the simulation
      * terminate.
-     * 
-     * @param r
-     *            the runnable to execute
+     *
+     * @param r the runnable to execute
      */
     void schedule(CheckedRunnable r);
 
     /**
-     * Sends a terminate command to the simulation. There is no guarantee on when
-     * this command will be actually processed.
+     * Sends a terminate command to the simulation.
+     * There is no guarantee on when this command will be actually processed.
      */
     void terminate();
 
     /**
-     * Suspends the caller until the simulation reaches the selected
-     * {@link Status}.
+     * Suspends the caller until the simulation reaches the selected {@link Status} or the timeout ends.
      *
-     * @param s
-     *            The {@link Status} the simulation must reach before returning
-     *            from this method
-     * @param timeout
-     *            The maximum lapse of time the caller wants to wait before
-     *            being resumed (0 means "no limit")
-     * @param timeunit
-     *            The {@link TimeUnit} used to define "timeout"
+     * Please note that waiting for a status does not mean that every {@link OutputMonitor} will already be
+     * notified of the update.
+     *
+     * @param s        The {@link Status} the simulation should reach before returning from this method
+     * @param timeout  The maximum lapse of time the caller wants to wait before being resumed
+     * @param timeunit The {@link TimeUnit} used to define "timeout"
      *
      * @return the status of the Simulation at the end of the wait
      */


### PR DESCRIPTION
As privately asked, I fixed `Simulation` interface Javadoc, specifically for `waitFor` method:

- Now doc clearly states that `waitFor` will return when timeout is over even if state is still different from expected;
- Now doc clearly states that synchronizing with `waitFor` does only synchronize with the internal simulation state, not with OutputMonitor update state;

Also:

- code was automatically formatted by Intellij IDEA;
- because of Intellij IDEA warning me to track personal configuration files that it auto-generated at project import, I updated the `.gitignore` documenting rules and ignoring those personal files.