### PR TITLE
Upgrade jirf from 0.2.1 to 0.2.2

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -135,6 +135,7 @@ version.org.apache.ignite..ignite-spring=2.7.0
 ##                           # available=2.8.0
 
 version.org.codehaus.groovy..groovy-jsr223=3.0.2
+##                             # available=3.0.3
 
 version.org.danilopianini..boilerplate=0.2.1
 
@@ -147,9 +148,10 @@ version.org.danilopianini..java-quadtree=0.1.3
 
 version.org.danilopianini..javalib-java7=0.6.1
 
-version.org.danilopianini..jirf=0.2.1
+version.org.danilopianini..jirf=0.2.2
 
 version.org.danilopianini..listset=0.2.5
+##                     # available=0.3.0
 
 version.org.danilopianini..thread-inheritable-resource-loader=0.3.2
 ##                                                # available=0.3.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.