### PR TITLE
Upgrade graphhopper-core from 0.12.0 to 0.13.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -47,8 +47,7 @@ version.com.google.guava..guava=28.2-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
-version.com.graphhopper..graphhopper-core=0.12.0
-##                            # available=0.13.0
+version.com.graphhopper..graphhopper-core=0.13.0
 ##                            # available=1.0-pre33.3
 
 version.com.graphhopper..graphhopper-reader-osm=0.12.0
@@ -134,6 +133,7 @@ version.org.apache.ignite..ignite-spring=2.7.0
 ##                           # available=2.8.0
 
 version.org.codehaus.groovy..groovy-jsr223=3.0.2
+##                             # available=3.0.3
 
 version.org.danilopianini..boilerplate=0.2.1
 
@@ -143,12 +143,15 @@ version.org.danilopianini..gson-extras=0.2.1
 ##                         # available=0.2.2
 
 version.org.danilopianini..java-quadtree=0.1.3
+##                           # available=0.1.4
 
 version.org.danilopianini..javalib-java7=0.6.1
 
 version.org.danilopianini..jirf=0.2.1
+##                  # available=0.2.4
 
 version.org.danilopianini..listset=0.2.5
+##                     # available=0.3.0
 
 version.org.danilopianini..thread-inheritable-resource-loader=0.3.2
 ##                                                # available=0.3.3
@@ -162,9 +165,10 @@ version.org.jgrapht..jgrapht-core=1.3.1
 version.org.jooq..jool-java-8=0.9.14
 
 version.org.junit.jupiter..junit-jupiter-api=5.5.2
-##                               # available=5.6.1
+##                               # available=5.6.2
 
 version.org.junit.jupiter..junit-jupiter-engine=5.6.1
+##                                  # available=5.6.2
 
 version.org.mapsforge..mapsforge-map-awt=0.11.0
 ##                           # available=0.13.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.