### PR TITLE
Upgrade graphhopper-core from 0.13.0 to 1.0-pre33.3

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -39,8 +39,7 @@ version.com.google.guava..guava=28.2-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
-version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre33.3
+version.com.graphhopper..graphhopper-core=1.0-pre33.3
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
 ##                                  # available=1.0-pre33.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.