### PR TITLE
Upgrade ignite-indexing from 2.7.0 to 2.8.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -102,8 +102,7 @@ version.org.apache.commons..commons-math3=3.6.1
 version.org.apache.ignite..ignite-core=2.7.0
 ##                         # available=2.8.0
 
-version.org.apache.ignite..ignite-indexing=2.7.0
-##                             # available=2.8.0
+version.org.apache.ignite..ignite-indexing=2.8.0
 
 version.org.apache.ignite..ignite-spring=2.7.0
 ##                           # available=2.8.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.