### PR TITLE
Upgrade ignite-spring from 2.7.0 to 2.8.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -105,8 +105,7 @@ version.org.apache.ignite..ignite-core=2.7.0
 version.org.apache.ignite..ignite-indexing=2.7.0
 ##                             # available=2.8.0
 
-version.org.apache.ignite..ignite-spring=2.7.0
-##                           # available=2.8.0
+version.org.apache.ignite..ignite-spring=2.8.0
 
 version.org.codehaus.groovy..groovy-jsr223=3.0.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.