### PR TITLE
Upgrade jirf from 0.2.4 to 0.2.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -121,8 +121,7 @@ version.org.danilopianini..java-quadtree=0.1.4
 
 version.org.danilopianini..javalib-java7=0.6.1
 
-version.org.danilopianini..jirf=0.2.4
-##                  # available=0.2.5
+version.org.danilopianini..jirf=0.2.5
 
 version.org.danilopianini..listset=0.3.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.