### PR TITLE
Upgrade thread-inheritable-resource-loader from 0.3.2 to 0.3.3

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -126,8 +126,7 @@ version.org.danilopianini..jirf=0.2.4
 
 version.org.danilopianini..listset=0.3.0
 
-version.org.danilopianini..thread-inheritable-resource-loader=0.3.2
-##                                                # available=0.3.3
+version.org.danilopianini..thread-inheritable-resource-loader=0.3.3
 
 version.org.jetbrains..annotations=17.0.0
 ##                     # available=19.0.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.