### PR TITLE
Upgrade mapsforge-map-awt from 0.11.0 to 0.13.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -141,8 +141,7 @@ version.org.junit.jupiter..junit-jupiter-api=5.6.2
 
 version.org.junit.jupiter..junit-jupiter-engine=5.6.2
 
-version.org.mapsforge..mapsforge-map-awt=0.11.0
-##                           # available=0.13.0
+version.org.mapsforge..mapsforge-map-awt=0.13.0
 
 version.org.protelis..protelis-interpreter=13.2.0
 ##                             # available=13.3.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.