### PR TITLE
Upgrade guava from 28.2-jre to 29.0-jre

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -28,28 +28,34 @@ version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.ben-manes.caffeine..caffeine=2.8.1
 
+version.com.github.cb372..scalacache-core_2.13=0.28.0
+
+version.com.github.cb372..scalacache-guava_2.13=0.28.0
+
 version.com.github.davidmoten..rtree=0.8.7
 
 version.com.github.spotbugs..spotbugs=4.0.1
 
 version.com.google.code.gson..gson=2.8.6
 
-version.com.google.guava..guava=28.2-jre
-##                  # available=29.0-jre
+version.com.google.guava..guava=29.0-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
 version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre33.3
+##                            # available=1.0-pre33.4
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre33.3
+##                                  # available=1.0-pre33.4
 
 version.com.javadocmd..simplelatlng=1.3.1
 
 version.com.miglayout..miglayout-swing=5.2
 
 version.com.uchuhimo..konf=0.22.1
+
+version.com.vladsch.flexmark..flexmark-all=0.35.10
+##                             # available=0.61.8
 
 version.commons-cli..commons-cli=1.4
 
@@ -81,7 +87,10 @@ version.io.kotest..kotest-assertions-core-jvm=4.0.2
 
 version.io.kotest..kotest-runner-junit5-jvm=4.0.2
 
+version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
+
 version.kotlin=1.3.71
+## # available=1.3.72
 
 version.net.sf.trove4j..trove4j=3.0.3
 
@@ -131,35 +140,13 @@ version.org.junit.jupiter..junit-jupiter-engine=5.6.2
 
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
-version.org.protelis..protelis-interpreter=13.3.2
-
-version.org.protelis..protelis-lang=13.3.2
-
-version.org.slf4j..slf4j-api=1.7.30
-##               # available=1.8.0-beta4
-##               # available=2.0.0-alpha1
-
-version.org.yaml..snakeyaml=1.26
-
-version.it.unibo.apice.scafiteam..scafi-core_2.12=0.3.2
-
-version.com.github.cb372..scalacache-core_2.12=0.28.0
-
-version.com.github.cb372..scalacache-guava_2.12=0.28.0
-
-version.org.scalatest..scalatest_2.12=3.1.1
-##                        # available=3.2.0-M4
-##                        # available=3.3.0-SNAP2
+version.org.parboiled..parboiled-java=1.3.1
 
 version.org.pegdown..pegdown=1.6.0
 
-version.org.parboiled..parboiled-java=1.3.1
+version.org.protelis..protelis-interpreter=13.3.2
 
-version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
-
-version.com.github.cb372..scalacache-core_2.13=0.28.0
-
-version.com.github.cb372..scalacache-guava_2.13=0.28.0
+version.org.protelis..protelis-lang=13.3.2
 
 version.org.scalatest..scalatest_2.13=3.1.1
 ##                        # available=3.2.0-M4
@@ -167,4 +154,8 @@ version.org.scalatest..scalatest_2.13=3.1.1
 
 version.org.scalatestplus..scalatestplus-junit_2.13=1.0.0-M2
 
-version.com.vladsch.flexmark..flexmark-all=0.35.10
+version.org.slf4j..slf4j-api=1.7.30
+##               # available=1.8.0-beta4
+##               # available=2.0.0-alpha1
+
+version.org.yaml..snakeyaml=1.26


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.