### PR TITLE
Upgrade graphhopper-reader-osm from 0.13.0 to 1.0-pre33.4

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -48,8 +48,7 @@ version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.
 version.com.graphhopper..graphhopper-core=0.13.0
 ##                            # available=1.0-pre33.4
 
-version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre33.4
+version.com.graphhopper..graphhopper-reader-osm=1.0-pre33.4
 
 version.com.javadocmd..simplelatlng=1.3.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.