### PR TITLE
Upgrade flexmark-profile-pegdown from 0.36.8 to 0.61.8

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -57,8 +57,7 @@ version.com.miglayout..miglayout-swing=5.2
 
 version.com.uchuhimo..konf=0.22.1
 
-version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.8
+version.com.vladsch.flexmark..flexmark-profile-pegdown=0.61.8
 
 version.commons-cli..commons-cli=1.4
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.