### PR TITLE
Upgrade kotest-runner-junit5-jvm from 4.0.2 to 4.0.3

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -89,8 +89,7 @@ version.io.jenetics..jpx=1.7.0
 version.io.kotest..kotest-assertions-core-jvm=4.0.2
 ##                                # available=4.0.3
 
-version.io.kotest..kotest-runner-junit5-jvm=4.0.2
-##                              # available=4.0.3
+version.io.kotest..kotest-runner-junit5-jvm=4.0.3
 
 version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.