### PR TITLE
Upgrade java-quadtree from 0.1.4 to 0.1.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -123,8 +123,7 @@ version.org.danilopianini..conrec=0.1.0
 
 version.org.danilopianini..gson-extras=0.2.2
 
-version.org.danilopianini..java-quadtree=0.1.4
-##                           # available=0.1.5
+version.org.danilopianini..java-quadtree=0.1.5
 
 version.org.danilopianini..javalib-java7=0.6.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.