### PR TITLE
Upgrade scalatest_2.13 from 3.2.0-M4 to 3.3.0-SNAP2

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -154,8 +154,7 @@ version.org.protelis..protelis-interpreter=13.3.2
 version.org.protelis..protelis-lang=13.3.2
 ##                      # available=13.3.3
 
-version.org.scalatest..scalatest_2.13=3.2.0-M4
-##                        # available=3.3.0-SNAP2
+version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 
 version.org.scalatestplus..scalatestplus-junit_2.13=1.0.0-M2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.