### PR TITLE
Upgrade jirf from 0.2.6 to 0.2.7

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -123,7 +123,7 @@ version.org.danilopianini..java-quadtree=0.1.5
 
 version.org.danilopianini..javalib-java7=0.6.1
 
-version.org.danilopianini..jirf=0.2.6
+version.org.danilopianini..jirf=0.2.7
 
 version.org.danilopianini..listset=0.3.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.