### PR TITLE
Upgrade classgraph from 4.8.69 to 4.8.70

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -57,7 +57,7 @@ version.com.miglayout..miglayout-swing=5.2
 version.com.uchuhimo..konf=0.22.1
 
 version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.8
+##                                         # available=0.61.10
 
 version.commons-cli..commons-cli=1.4
 
@@ -65,7 +65,7 @@ version.commons-codec..commons-codec=1.14
 
 version.commons-io..commons-io=2.6
 
-version.io.github.classgraph..classgraph=4.8.69
+version.io.github.classgraph..classgraph=4.8.70
 
 version.io.github.javaeden.orchid..OrchidEditorial=0.20.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.