### PR TITLE
Upgrade protelis-interpreter from 13.3.3 to 13.3.4

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -57,7 +57,7 @@ version.com.miglayout..miglayout-swing=5.2
 version.com.uchuhimo..konf=0.22.1
 
 version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.10
+##                                         # available=0.61.12
 
 version.commons-cli..commons-cli=1.4
 
@@ -66,6 +66,7 @@ version.commons-codec..commons-codec=1.14
 version.commons-io..commons-io=2.6
 
 version.io.github.classgraph..classgraph=4.8.70
+##                           # available=4.8.71
 
 version.io.github.javaeden.orchid..OrchidEditorial=0.20.0
 
@@ -141,9 +142,10 @@ version.org.junit.jupiter..junit-jupiter-engine=5.6.2
 
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
-version.org.protelis..protelis-interpreter=13.3.3
+version.org.protelis..protelis-interpreter=13.3.4
 
 version.org.protelis..protelis-lang=13.3.3
+##                      # available=13.3.4
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.