### PR TITLE
Upgrade flexmark-profile-pegdown from 0.36.8 to 0.61.16

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -56,8 +56,7 @@ version.com.miglayout..miglayout-swing=5.2
 
 version.com.uchuhimo..konf=0.22.1
 
-version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.12
+version.com.vladsch.flexmark..flexmark-profile-pegdown=0.61.16
 
 version.commons-cli..commons-cli=1.4
 
@@ -142,8 +141,10 @@ version.org.junit.jupiter..junit-jupiter-engine=5.6.2
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
 version.org.protelis..protelis-interpreter=13.3.4
+##                             # available=13.3.5
 
 version.org.protelis..protelis-lang=13.3.4
+##                      # available=13.3.5
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.