### PR TITLE
Upgrade junit-jupiter-engine from 5.6.2 to 5.7.0-M1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -136,8 +136,9 @@ version.org.jgrapht..jgrapht-core=1.4.0
 version.org.jooq..jool-java-8=0.9.14
 
 version.org.junit.jupiter..junit-jupiter-api=5.6.2
+##                               # available=5.7.0-M1
 
-version.org.junit.jupiter..junit-jupiter-engine=5.6.2
+version.org.junit.jupiter..junit-jupiter-engine=5.7.0-M1
 
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.