### PR TITLE
Upgrade graphhopper-core from 0.13.0 to 1.0-pre34

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -45,11 +45,10 @@ version.com.google.guava..guava=29.0-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
-version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre33.4
+version.com.graphhopper..graphhopper-core=1.0-pre34
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre33.4
+##                                  # available=1.0-pre34
 
 version.com.javadocmd..simplelatlng=1.3.1
 
@@ -67,6 +66,7 @@ version.commons-codec..commons-codec=1.14
 version.commons-io..commons-io=2.6
 
 version.io.github.classgraph..classgraph=4.8.72
+##                           # available=4.8.73
 
 version.io.github.javaeden.orchid..OrchidEditorial=0.20.0
 
@@ -144,8 +144,10 @@ version.org.junit.jupiter..junit-jupiter-engine=5.7.0-M1
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
 version.org.protelis..protelis-interpreter=13.3.5
+##                             # available=13.3.6
 
 version.org.protelis..protelis-lang=13.3.5
+##                      # available=13.3.6
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.