### PR TITLE
Upgrade protelis-lang from 13.3.6 to 13.3.7

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -46,10 +46,10 @@ version.com.google.guava..guava=29.0-jre
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
 version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre34
+##                            # available=1.0-pre35
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre34
+##                                  # available=1.0-pre35
 
 version.com.javadocmd..simplelatlng=1.3.1
 
@@ -58,7 +58,7 @@ version.com.miglayout..miglayout-swing=5.2
 version.com.uchuhimo..konf=0.22.1
 
 version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.16
+##                                         # available=0.61.18
 
 version.commons-cli..commons-cli=1.4
 
@@ -67,7 +67,7 @@ version.commons-codec..commons-codec=1.14
 version.commons-io..commons-io=2.6
 
 version.io.github.classgraph..classgraph=4.8.72
-##                           # available=4.8.73
+##                           # available=4.8.75
 
 version.io.github.javaeden.orchid..OrchidEditorial=0.20.0
 
@@ -87,10 +87,13 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.7.4
 ##                                         # available=1.8.0
 
 version.io.jenetics..jpx=1.7.0
+##           # available=2.0.0
 
 version.io.kotest..kotest-assertions-core-jvm=4.0.3
+##                                # available=4.0.4
 
 version.io.kotest..kotest-runner-junit5-jvm=4.0.3
+##                              # available=4.0.4
 
 version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 
@@ -145,9 +148,9 @@ version.org.junit.jupiter..junit-jupiter-engine=5.7.0-M1
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
 version.org.protelis..protelis-interpreter=13.3.5
-##                             # available=13.3.6
+##                             # available=13.3.7
 
-version.org.protelis..protelis-lang=13.3.6
+version.org.protelis..protelis-lang=13.3.7
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.