### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.4 to 4.0.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -13,6 +13,7 @@ plugin.com.github.johnrengelman.shadow=5.2.0
 plugin.com.github.maiflai.scalatest=0.26
 
 plugin.com.github.spotbugs=4.0.5
+##             # available=4.0.6
 
 plugin.com.jfrog.bintray=1.8.5
 
@@ -45,10 +46,10 @@ version.com.google.guava..guava=29.0-jre
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
 version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre35
+##                            # available=1.0-pre36
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre35
+##                                  # available=1.0-pre36
 
 version.com.javadocmd..simplelatlng=1.3.1
 
@@ -57,7 +58,7 @@ version.com.miglayout..miglayout-swing=5.2
 version.com.uchuhimo..konf=0.22.1
 
 version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.18
+##                                         # available=0.61.20
 
 version.commons-cli..commons-cli=1.4
 
@@ -85,9 +86,10 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.8.0
 
 version.io.jenetics..jpx=2.0.0
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.4
+version.io.kotest..kotest-assertions-core-jvm=4.0.5
 
 version.io.kotest..kotest-runner-junit5-jvm=4.0.4
+##                              # available=4.0.5
 
 version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.