### PR TITLE
Upgrade graphhopper-core from 0.13.0 to 1.0-pre37

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -13,6 +13,7 @@ plugin.com.github.johnrengelman.shadow=5.2.0
 plugin.com.github.maiflai.scalatest=0.26
 
 plugin.com.github.spotbugs=4.0.6
+##             # available=4.0.7
 
 plugin.com.jfrog.bintray=1.8.5
 
@@ -29,6 +30,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.ben-manes.caffeine..caffeine=2.8.1
+##                                  # available=2.8.2
 
 version.com.github.cb372..scalacache-core_2.13=0.28.0
 
@@ -44,11 +46,10 @@ version.com.google.guava..guava=29.0-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
-version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre36
+version.com.graphhopper..graphhopper-core=1.0-pre37
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre36
+##                                  # available=1.0-pre37
 
 version.com.javadocmd..simplelatlng=1.3.1
 
@@ -66,6 +67,7 @@ version.commons-codec..commons-codec=1.14
 version.commons-io..commons-io=2.6
 
 version.io.github.classgraph..classgraph=4.8.75
+##                           # available=4.8.77
 
 version.io.github.javaeden.orchid..OrchidEditorial=0.20.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.