### PR TITLE
Upgrade protelis-interpreter from 13.3.7 to 13.3.8

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -57,7 +57,7 @@ version.com.miglayout..miglayout-swing=5.2
 version.com.uchuhimo..konf=0.22.1
 
 version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.20
+##                                         # available=0.61.24
 
 version.commons-cli..commons-cli=1.4
 
@@ -141,9 +141,10 @@ version.org.junit.jupiter..junit-jupiter-engine=5.7.0-M1
 
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
-version.org.protelis..protelis-interpreter=13.3.7
+version.org.protelis..protelis-interpreter=13.3.8
 
 version.org.protelis..protelis-lang=13.3.7
+##                      # available=13.3.8
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.