### PR TITLE
Upgrade graphhopper-core from 0.13.0 to 1.0-pre39

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -44,11 +44,10 @@ version.com.google.guava..guava=29.0-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
-version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre38
+version.com.graphhopper..graphhopper-core=1.0-pre39
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre38
+##                                  # available=1.0-pre39
 
 version.com.javadocmd..simplelatlng=1.3.1
 
@@ -66,6 +65,7 @@ version.commons-codec..commons-codec=1.14
 version.commons-io..commons-io=2.6
 
 version.io.github.classgraph..classgraph=4.8.77
+##                           # available=4.8.78
 
 version.io.github.javaeden.orchid..OrchidEditorial=0.20.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.