### PR TITLE
Upgrade graphhopper-reader-osm from 0.13.0 to 1.0-pre40

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -45,10 +45,9 @@ version.com.google.guava..guava=29.0-jre
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
 version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre39
+##                            # available=1.0-pre40
 
-version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre39
+version.com.graphhopper..graphhopper-reader-osm=1.0-pre40
 
 version.com.javadocmd..simplelatlng=1.3.1
 
@@ -57,7 +56,7 @@ version.com.miglayout..miglayout-swing=5.2
 version.com.uchuhimo..konf=0.22.1
 
 version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.24
+##                                         # available=0.61.26
 
 version.commons-cli..commons-cli=1.4
 
@@ -126,6 +125,7 @@ version.org.danilopianini..javalib-java7=0.6.1
 version.org.danilopianini..jirf=0.2.7
 
 version.org.danilopianini..listset=0.3.2
+##                     # available=0.3.3
 
 version.org.danilopianini..thread-inheritable-resource-loader=0.3.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.