### PR TITLE
Upgrade graphhopper-core from 0.13.0 to 1.0-pre42

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -37,6 +37,7 @@ version.com.github.cb372..scalacache-guava_2.13=0.28.0
 version.com.github.davidmoten..rtree=0.8.7
 
 version.com.github.spotbugs..spotbugs=4.0.2
+##                        # available=4.0.3
 
 version.com.google.code.gson..gson=2.8.6
 
@@ -44,11 +45,10 @@ version.com.google.guava..guava=29.0-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
-version.com.graphhopper..graphhopper-core=0.13.0
-##                            # available=1.0-pre40
+version.com.graphhopper..graphhopper-core=1.0-pre42
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0
-##                                  # available=1.0-pre40
+##                                  # available=1.0-pre42
 
 version.com.javadocmd..simplelatlng=1.3.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.