### PR TITLE
Upgrade flexmark-profile-pegdown from 0.36.8 to 0.61.28

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -13,6 +13,7 @@ plugin.com.github.johnrengelman.shadow=5.2.0
 plugin.com.github.maiflai.scalatest=0.26
 
 plugin.com.github.spotbugs=4.1.0
+##             # available=4.2.0
 
 plugin.com.jfrog.bintray=1.8.5
 
@@ -56,8 +57,7 @@ version.com.miglayout..miglayout-swing=5.2
 
 version.com.uchuhimo..konf=0.22.1
 
-version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.26
+version.com.vladsch.flexmark..flexmark-profile-pegdown=0.61.28
 
 version.commons-cli..commons-cli=1.4
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.