### PR TITLE
Upgrade io.gitlab.arturbosch.detekt from 1.9.0 to 1.9.1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -16,7 +16,7 @@ plugin.com.github.spotbugs=4.2.0
 
 plugin.com.jfrog.bintray=1.8.5
 
-plugin.io.gitlab.arturbosch.detekt=1.9.0
+plugin.io.gitlab.arturbosch.detekt=1.9.1
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
@@ -29,6 +29,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.ben-manes.caffeine..caffeine=2.8.2
+##                                  # available=2.8.3
 
 version.com.github.cb372..scalacache-core_2.13=0.28.0
 
@@ -57,7 +58,7 @@ version.com.miglayout..miglayout-swing=5.2
 version.com.uchuhimo..konf=0.22.1
 
 version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
-##                                         # available=0.61.28
+##                                         # available=0.61.30
 
 version.commons-cli..commons-cli=1.4
 
@@ -82,6 +83,7 @@ version.io.github.javaeden.orchid..OrchidSyntaxHighlighter=0.20.0
 version.io.github.javaeden.orchid..OrchidWiki=0.20.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.9.0
+##                                         # available=1.9.1
 
 version.io.jenetics..jpx=2.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.