### PR TITLE
Upgrade caffeine from 2.8.3 to 2.8.4

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -28,7 +28,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
-version.com.github.ben-manes.caffeine..caffeine=2.8.3
+version.com.github.ben-manes.caffeine..caffeine=2.8.4
 
 version.com.github.cb372..scalacache-core_2.13=0.28.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.