### PR TITLE
Upgrade graphhopper-core from 0.13.0 to 1.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -44,7 +44,7 @@ version.com.google.guava..guava=29.0-jre
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 
-version.com.graphhopper..graphhopper-core=0.13.0
+version.com.graphhopper..graphhopper-core=1.0
 ##                            # available=1.0-pre42
 
 version.com.graphhopper..graphhopper-reader-osm=0.13.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.