### PR TITLE
Upgrade commons-io from 2.6 to 2.7

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -63,7 +63,7 @@ version.commons-cli..commons-cli=1.4
 
 version.commons-codec..commons-codec=1.14
 
-version.commons-io..commons-io=2.6
+version.commons-io..commons-io=2.7
 
 version.io.github.classgraph..classgraph=4.8.78
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.