### PR TITLE
Upgrade ignite-spring from 2.8.0 to 2.8.1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -109,7 +109,7 @@ version.org.apache.ignite..ignite-core=2.8.1
 
 version.org.apache.ignite..ignite-indexing=2.8.1
 
-version.org.apache.ignite..ignite-spring=2.8.0
+version.org.apache.ignite..ignite-spring=2.8.1
 
 version.org.codehaus.groovy..groovy-jsr223=3.0.4
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.