### PR TITLE
Upgrade slf4j-api from 1.8.0-beta4 to 2.0.0-alpha1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -149,7 +149,6 @@ version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 
 version.org.scalatestplus..scalatestplus-junit_2.13=1.0.0-M2
 
-version.org.slf4j..slf4j-api=1.8.0-beta4
-##               # available=2.0.0-alpha1
+version.org.slf4j..slf4j-api=2.0.0-alpha1
 
 version.org.yaml..snakeyaml=1.26


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.