### PR TITLE
Upgrade OrchidSearch from 0.20.0 to 0.21.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -75,7 +75,7 @@ version.io.github.javaeden.orchid..OrchidKotlindoc=0.21.0
 
 version.io.github.javaeden.orchid..OrchidPluginDocs=0.21.0
 
-version.io.github.javaeden.orchid..OrchidSearch=0.20.0
+version.io.github.javaeden.orchid..OrchidSearch=0.21.0
 
 version.io.github.javaeden.orchid..OrchidSyntaxHighlighter=0.20.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.