### PR TITLE
Upgrade OrchidWiki from 0.20.0 to 0.21.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -79,7 +79,7 @@ version.io.github.javaeden.orchid..OrchidSearch=0.21.0
 
 version.io.github.javaeden.orchid..OrchidSyntaxHighlighter=0.21.0
 
-version.io.github.javaeden.orchid..OrchidWiki=0.20.0
+version.io.github.javaeden.orchid..OrchidWiki=0.21.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.9.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.