### PR TITLE
Upgrade kotest-runner-junit5-jvm from 4.0.5 to 4.0.6

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -87,7 +87,7 @@ version.io.jenetics..jpx=2.0.0
 
 version.io.kotest..kotest-assertions-core-jvm=4.0.6
 
-version.io.kotest..kotest-runner-junit5-jvm=4.0.5
+version.io.kotest..kotest-runner-junit5-jvm=4.0.6
 
 version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.