### PR TITLE
Upgrade thread-inheritable-resource-loader from 0.3.3 to 0.3.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -127,7 +127,7 @@ version.org.danilopianini..jirf=0.2.7
 
 version.org.danilopianini..listset=0.3.4
 
-version.org.danilopianini..thread-inheritable-resource-loader=0.3.3
+version.org.danilopianini..thread-inheritable-resource-loader=0.3.5
 
 version.org.jetbrains..annotations=19.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.