### PR TITLE
Upgrade protelis-interpreter from 13.3.8 to 13.3.9

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -141,7 +141,7 @@ version.org.junit.jupiter..junit-jupiter-engine=5.7.0-M1
 
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
-version.org.protelis..protelis-interpreter=13.3.8
+version.org.protelis..protelis-interpreter=13.3.9
 
 version.org.protelis..protelis-lang=13.3.8
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.