### PR TITLE
Upgrade protelis-lang from 13.3.8 to 13.3.9

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -143,7 +143,7 @@ version.org.mapsforge..mapsforge-map-awt=0.13.0
 
 version.org.protelis..protelis-interpreter=13.3.9
 
-version.org.protelis..protelis-lang=13.3.8
+version.org.protelis..protelis-lang=13.3.9
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.