### PR TITLE
Upgrade flexmark-profile-pegdown from 0.36.8 to 0.62.2

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -56,7 +56,7 @@ version.com.miglayout..miglayout-swing=5.2
 
 version.com.uchuhimo..konf=0.22.1
 
-version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
+version.com.vladsch.flexmark..flexmark-profile-pegdown=0.62.2
 ##                                         # available=0.61.30
 
 version.commons-cli..commons-cli=1.4


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.