### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.6 to 4.1.0.RC1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -85,7 +85,7 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.9.1
 
 version.io.jenetics..jpx=2.0.0
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.6
+version.io.kotest..kotest-assertions-core-jvm=4.1.0.RC1
 
 version.io.kotest..kotest-runner-junit5-jvm=4.0.6
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.