### PR TITLE
Upgrade io.gitlab.arturbosch.detekt from 1.9.1 to 1.10.0-RC1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -11,7 +11,7 @@ plugin.com.github.spotbugs=4.3.0
 
 plugin.com.jfrog.bintray=1.8.5
 
-plugin.io.gitlab.arturbosch.detekt=1.9.1
+plugin.io.gitlab.arturbosch.detekt=1.10.0-RC1
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.