### PR TITLE
Upgrade logback-classic from 1.2.3 to 1.3.0-alpha5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -21,7 +21,7 @@ plugin.org.jetbrains.dokka=0.10.1
 
 plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
-version.ch.qos.logback..logback-classic=1.2.3
+version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.github.ben-manes.caffeine..caffeine=2.8.4
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.