### PR TITLE
Upgrade jirf from 0.2.7 to 0.3.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -119,7 +119,7 @@ version.org.danilopianini..java-quadtree=0.1.5
 
 version.org.danilopianini..javalib-java7=0.6.1
 
-version.org.danilopianini..jirf=0.2.7
+version.org.danilopianini..jirf=0.3.0
 
 version.org.danilopianini..listset=0.3.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.