### PR TITLE
Upgrade OrchidSearch from 0.21.0 to 0.21.1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -71,7 +71,7 @@ version.io.github.javaeden.orchid..OrchidKotlindoc=0.21.1
 
 version.io.github.javaeden.orchid..OrchidPluginDocs=0.21.1
 
-version.io.github.javaeden.orchid..OrchidSearch=0.21.0
+version.io.github.javaeden.orchid..OrchidSearch=0.21.1
 
 version.io.github.javaeden.orchid..OrchidSyntaxHighlighter=0.21.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.