### PR TITLE
Upgrade spotbugs from 4.0.4 to 4.0.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -31,7 +31,7 @@ version.com.github.cb372..scalacache-guava_2.13=0.28.0
 
 version.com.github.davidmoten..rtree=0.8.7
 
-version.com.github.spotbugs..spotbugs=4.0.4
+version.com.github.spotbugs..spotbugs=4.0.5
 
 version.com.google.code.gson..gson=2.8.6
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.