### PR TITLE
Upgrade spotbugs from 4.0.5 to 4.0.6

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -34,7 +34,7 @@ version.com.github.ben-manes.caffeine..caffeine=2.8.4
 
 version.com.github.davidmoten..rtree=0.8.7
 
-version.com.github.spotbugs..spotbugs=4.0.5
+version.com.github.spotbugs..spotbugs=4.0.6
 
 version.com.google.code.gson..gson=2.8.6
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.