### PR TITLE
Upgrade kotest from 4.1.0.RC2 to 4.1.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -72,7 +72,7 @@ version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 
 version.junit=5.7.0-M1
 
-version.kotest=4.1.0.RC2
+version.kotest=4.1.0
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.