### PR TITLE
Upgrade caffeine from 2.8.4 to 2.8.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -32,7 +32,7 @@ version.apache.ignite=2.8.1
 
 version.ch.qos.logback..logback-classic=1.2.3
 
-version.com.github.ben-manes.caffeine..caffeine=2.8.4
+version.com.github.ben-manes.caffeine..caffeine=2.8.5
 
 version.com.github.davidmoten..rtree=0.8.7
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.