### PR TITLE
Upgrade mockito-core from 3.3.3 to 3.4.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -112,7 +112,7 @@ version.org.jooq..jool-java-8=0.9.14
 
 version.org.mapsforge..mapsforge-map-awt=0.13.0
 
-version.org.mockito..mockito-core=3.3.3
+version.org.mockito..mockito-core=3.4.0
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.