### PR TITLE
Upgrade groovy-jsr223 from 3.0.4 to 3.0.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -86,7 +86,7 @@ version.org.apache.commons..commons-lang3=3.11
 
 version.org.apache.commons..commons-math3=3.6.1
 
-version.org.codehaus.groovy..groovy-jsr223=3.0.4
+version.org.codehaus.groovy..groovy-jsr223=3.0.5
 
 version.org.danilopianini..boilerplate=0.2.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.