### PR TITLE
Upgrade spotbugs from 4.4.5 to 4.5.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -12,7 +12,7 @@ plugin.com.github.johnrengelman.shadow=6.0.0
 
 plugin.com.github.maiflai.scalatest=0.26
 
-plugin.com.github.spotbugs=4.4.5
+plugin.com.github.spotbugs=4.5.0
 
 plugin.com.jfrog.bintray=1.8.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.