### PR TITLE
Upgrade detekt-formatting from 1.11.0-RC2 to 1.11.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -66,7 +66,7 @@ version.graphhopper=1.0
 
 version.io.github.classgraph..classgraph=4.8.87
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.0-RC2
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.0
 
 version.io.jenetics..jpx=2.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.