### PR TITLE
Upgrade spotbugs from 4.1.1 to 4.1.2

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -38,7 +38,7 @@ version.com.github.ben-manes.caffeine..caffeine=2.8.5
 
 version.com.github.davidmoten..rtree=0.8.7
 
-version.com.github.spotbugs..spotbugs=4.1.1
+version.com.github.spotbugs..spotbugs=4.1.2
 
 version.com.google.code.gson..gson=2.8.6
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.