### PR TITLE
Upgrade detekt-formatting from 1.12.0-RC1 to 1.12.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -67,7 +67,7 @@ version.graphhopper=1.0
 
 version.io.github.classgraph..classgraph=4.8.89
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0-RC1
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0
 
 version.io.jenetics..jpx=2.0.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.