### PR TITLE
Upgrade commons-codec from 1.14 to 1.15

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -59,7 +59,7 @@ version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
 
 version.commons-cli..commons-cli=1.4
 
-version.commons-codec..commons-codec=1.14
+version.commons-codec..commons-codec=1.15
 
 version.commons-io..commons-io=2.7
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.