### PR TITLE
Upgrade mockito-core from 3.5.9 to 3.5.10

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -115,7 +115,7 @@ version.org.jooq..jool-java-8=0.9.14
 
 version.org.mapsforge..mapsforge-map-awt=0.14.0
 
-version.org.mockito..mockito-core=3.5.9
+version.org.mockito..mockito-core=3.5.10
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.