### PR TITLE
Upgrade commons-io from 2.7 to 2.8.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -61,7 +61,7 @@ version.commons-cli..commons-cli=1.4
 
 version.commons-codec..commons-codec=1.15
 
-version.commons-io..commons-io=2.7
+version.commons-io..commons-io=2.8.0
 
 version.graphhopper=1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.