### PR TITLE
Upgrade kotest from 4.2.4 to 4.2.5

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -75,7 +75,7 @@ version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 
 version.junit-jupiter=5.7.0-M1
 
-version.kotest=4.2.4
+version.kotest=4.2.5
 
 version.kotlin=1.4.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.