### PR TITLE
Upgrade groovy-jsr223 from 3.0.5 to 3.0.6

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -101,7 +101,7 @@ version.org.apache.commons..commons-lang3=3.11
 
 version.org.apache.commons..commons-math3=3.6.1
 
-version.org.codehaus.groovy..groovy-jsr223=3.0.5
+version.org.codehaus.groovy..groovy-jsr223=3.0.6
 
 version.org.controlsfx..controlsfx=11.0.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.