### PR TITLE
Upgrade spotbugs from 4.5.0 to 4.5.1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -13,7 +13,7 @@ plugin.com.github.johnrengelman.shadow=6.0.0
 
 plugin.com.github.maiflai.scalatest=0.26
 
-plugin.com.github.spotbugs=4.5.0
+plugin.com.github.spotbugs=4.5.1
 
 plugin.com.jfrog.bintray=1.8.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.