### PR TITLE
Upgrade kotest from 4.2.5 to 4.2.6

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -83,7 +83,7 @@ version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 
 version.junit-jupiter=5.7.0
 
-version.kotest=4.2.5
+version.kotest=4.2.6
 
 version.kotlin=1.4.10
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.