### PR TITLE
Upgrade graphhopper from 1.0 to 2.1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -71,7 +71,7 @@ version.commons-io..commons-io=2.8.0
 
 version.de.codecentric.centerdevice..javafxsvg=1.3.0
 
-version.graphhopper=1.0
+version.graphhopper=2.1
 
 version.io.github.classgraph..classgraph=4.8.90
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.