### PR TITLE
Upgrade guava from 29.0-jre to 30.0-android

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -49,7 +49,7 @@ version.com.github.spotbugs..spotbugs=4.1.3
 
 version.com.google.code.gson..gson=2.8.6
 
-version.com.google.guava..guava=29.0-jre
+version.com.google.guava..guava=30.0-android
 
 version.com.googlecode.concurrentlinkedhashmap..concurrentlinkedhashmap-lru=1.4.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.