### PR TITLE
Upgrade scala from 2.13.3 to 2.13.4

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -143,7 +143,7 @@ version.org.yaml..snakeyaml=1.27
 
 version.protelis=14.0.0
 
-version.scala=2.13.3
+version.scala=2.13.4
 
 version.scalacache=0.28.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.