### PR TITLE
Upgrade jpx from 2.0.0 to 2.1.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -75,7 +75,7 @@ version.io.github.classgraph..classgraph=4.8.90
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
 
-version.io.jenetics..jpx=2.0.0
+version.io.jenetics..jpx=2.1.0
 
 version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.