### PR TITLE
Upgrade caffeine from 2.8.6 to 2.8.7

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -35,7 +35,7 @@ version.apache.ignite=2.9.0
 
 version.ch.qos.logback..logback-classic=1.2.3
 
-version.com.github.ben-manes.caffeine..caffeine=2.8.6
+version.com.github.ben-manes.caffeine..caffeine=2.8.7
 
 version.com.github.davidmoten..rtree=0.8.7
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.