### PR TITLE
Upgrade kotest from 4.3.1 to 4.3.2

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -85,7 +85,7 @@ version.it.unimi.dsi..dsiutils=2.6.16
 
 version.junit-jupiter=5.7.0
 
-version.kotest=4.3.1
+version.kotest=4.3.2
 
 version.kotlin=1.4.21
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.