### PR TITLE
Upgrade detekt-formatting from 1.14.2 to 1.15.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -75,7 +75,7 @@ version.io.arrow-kt..arrow-core=0.11.0
 
 version.io.github.classgraph..classgraph=4.8.96
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
 version.io.jenetics..jpx=2.1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.