### PR TITLE
Upgrade classgraph from 4.8.95 to 4.8.97

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -73,7 +73,7 @@ version.graphhopper=2.3
 
 version.io.arrow-kt..arrow-core=0.11.0
 
-version.io.github.classgraph..classgraph=4.8.95
+version.io.github.classgraph..classgraph=4.8.97
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.