### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -19,7 +19,7 @@ plugin.de.aaschmid.cpd=3.1
 
 plugin.io.gitlab.arturbosch.detekt=version.io.gitlab.arturbosch.detekt..detekt-formatting
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
 plugin.org.danilopianini.publish-on-central=0.4.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.