### PR TITLE
Upgrade ignite from 2.9.0 to 2.9.1

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -31,7 +31,7 @@ version..konf=0.23.0
 
 version.antlr4=4.9
 
-version.apache.ignite=2.9.0
+version.apache.ignite=2.9.1
 
 version.ch.qos.logback..logback-classic=1.2.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.