### PR TITLE
Upgrade mapsforge-map-awt from 0.14.0 to 0.15.0

### DIFF
--- a/alchemist/versions.properties
+++ b/alchemist/versions.properties
@@ -139,7 +139,7 @@ version.org.jgrapht..jgrapht-core=1.5.0
 
 version.org.jooq..jool-java-8=0.9.14
 
-version.org.mapsforge..mapsforge-map-awt=0.14.0
+version.org.mapsforge..mapsforge-map-awt=0.15.0
 
 version.org.mockito..mockito-core=3.6.28
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.