### PR TITLE
Upgrade flexmark-profile-pegdown from 0.36.8 to 0.62.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -61,7 +61,7 @@ version.com.miglayout..miglayout-swing=11.0
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.com.vladsch.flexmark..flexmark-profile-pegdown=0.36.8
+version.com.vladsch.flexmark..flexmark-profile-pegdown=0.62.2
 
 version.commons-cli..commons-cli=1.4
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.