### PR TITLE
Upgrade mockito-core from 3.7.0 to 3.7.7

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -141,7 +141,7 @@ version.org.jooq..jool-java-8=0.9.14
 
 version.org.mapsforge..mapsforge-map-awt=0.15.0
 
-version.org.mockito..mockito-core=3.7.0
+version.org.mockito..mockito-core=3.7.7
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.