### PR TITLE
Upgrade jpx from 2.1.0 to 2.2.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -77,7 +77,7 @@ version.io.github.classgraph..classgraph=4.8.98
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
-version.io.jenetics..jpx=2.1.0
+version.io.jenetics..jpx=2.2.0
 
 version.it.unibo.apice.scafiteam..scafi-core_2.13=v0.3.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.