### PR TITLE
Upgrade classgraph from 4.8.98 to 4.8.100

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -73,7 +73,7 @@ version.graphhopper=2.3
 
 version.io.arrow-kt..arrow-core=0.11.0
 
-version.io.github.classgraph..classgraph=4.8.98
+version.io.github.classgraph..classgraph=4.8.100
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.