### PR TITLE
Upgrade caffeine from 2.8.8 to 2.9.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -35,7 +35,7 @@ version.apache.ignite=2.9.1
 
 version.ch.qos.logback..logback-classic=1.2.3
 
-version.com.github.ben-manes.caffeine..caffeine=2.8.8
+version.com.github.ben-manes.caffeine..caffeine=2.9.0
 
 version.com.github.davidmoten..rtree=0.8.7
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.