### PR TITLE
Upgrade spotbugs from 4.6.1 to 4.6.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,7 @@ plugin.com.github.johnrengelman.shadow=6.1.0
 
 plugin.com.github.maiflai.scalatest=0.30
 
-plugin.com.github.spotbugs=4.6.1
+plugin.com.github.spotbugs=4.6.2
 
 plugin.de.aaschmid.cpd=3.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.