### PR TITLE
Upgrade ignite from 2.9.1 to 2.10.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -31,7 +31,7 @@ version..konf=1.0.0
 
 version.antlr4=4.9.2
 
-version.apache.ignite=2.9.1
+version.apache.ignite=2.10.0
 
 version.ch.qos.logback..logback-classic=1.2.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.