### PR TITLE
Upgrade arrow-core from 0.11.0 to 0.12.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -71,7 +71,7 @@ version.de.codecentric.centerdevice..javafxsvg=1.3.0
 
 version.graphhopper=2.3
 
-version.io.arrow-kt..arrow-core=0.11.0
+version.io.arrow-kt..arrow-core=0.12.0
 
 version.io.github.classgraph..classgraph=4.8.104
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.