### PR TITLE
Upgrade mockito-core from 3.8.0 to 3.9.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -145,7 +145,7 @@ version.org.jooq..jool=0.9.14
 
 version.org.mapsforge..mapsforge-map-awt=0.15.0
 
-version.org.mockito..mockito-core=3.8.0
+version.org.mockito..mockito-core=3.9.0
 
 version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.