### PR TITLE
Upgrade graphhopper from 2.3 to 2.4

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -69,7 +69,7 @@ version.commons-io..commons-io=2.8.0
 
 version.de.codecentric.centerdevice..javafxsvg=1.3.0
 
-version.graphhopper=2.3
+version.graphhopper=2.4
 
 version.io.arrow-kt..arrow-core=0.13.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.