### PR TITLE
Upgrade scala from 2.13.5 to 2.13.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -161,6 +161,6 @@ version.org.yaml..snakeyaml=1.28
 
 version.protelis=14.1.9
 
-version.scala=2.13.5
+version.scala=2.13.6
 
 version.scalacache=0.28.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.