### PR TITLE
Upgrade kotest from 4.5.0 to 4.6.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -87,7 +87,7 @@ version.it.unimi.dsi..dsiutils=2.6.17
 
 version.junit-jupiter=5.7.2
 
-version.kotest=4.5.0
+version.kotest=4.6.0
 
 version.kotlin=1.5.10
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.