### PR TITLE
Upgrade detekt-formatting from 1.17.0 to 1.17.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -77,7 +77,7 @@ version.io.arrow-kt..arrow-core=0.13.2
 
 version.io.github.classgraph..classgraph=4.8.105
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.0
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
 version.io.jenetics..jpx=2.2.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.