### PR TITLE
Upgrade mapsforge-map-awt from 0.15.0 to 0.16.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -147,7 +147,7 @@ version.org.jgrapht..jgrapht-core=1.5.1
 
 version.org.jooq..jool=0.9.14
 
-version.org.mapsforge..mapsforge-map-awt=0.15.0
+version.org.mapsforge..mapsforge-map-awt=0.16.0
 
 version.org.mockito..mockito-core=3.10.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.