### PR TITLE
Upgrade commons-io from 2.9.0 to 2.10.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -67,7 +67,7 @@ version.commons-cli..commons-cli=1.4
 
 version.commons-codec..commons-codec=1.15
 
-version.commons-io..commons-io=2.9.0
+version.commons-io..commons-io=2.10.0
 
 version.de.codecentric.centerdevice..javafxsvg=1.3.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.