### PR TITLE
Upgrade slf4j-api from 1.7.30 to 1.7.31

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -157,7 +157,7 @@ version.org.scalatest..scalatest_2.13=3.3.0-SNAP2
 
 version.org.scalatestplus..scalatestplus-junit_2.13=1.0.0-M2
 
-version.org.slf4j..slf4j-api=1.7.30
+version.org.slf4j..slf4j-api=1.7.31
 
 version.org.yaml..snakeyaml=1.29
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.