### PR TITLE
Upgrade kotest from 4.6.0 to 4.6.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -85,7 +85,7 @@ version.it.unimi.dsi..dsiutils=2.6.17
 
 version.junit-jupiter=5.7.2
 
-version.kotest=4.6.0
+version.kotest=4.6.1
 
 version.kotlin=1.5.20
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.