### PR TITLE
fix(incarnation-scafi): return null in createT instead of throwing exception

### DIFF
--- a/alchemist-incarnation-scafi/src/main/scala/it/unibo/alchemist/model/implementations/nodes/ScafiNode.scala
+++ b/alchemist-incarnation-scafi/src/main/scala/it/unibo/alchemist/model/implementations/nodes/ScafiNode.scala
@@ -12,7 +12,7 @@ import it.unibo.alchemist.model.interfaces.{Environment, Molecule, Position, Tim
 class ScafiNode[T, P<:Position[P]](env: Environment[T, P]) extends AbstractNode[T](env) {
   private var lastAccessedMolecule: Molecule = null
 
-  override def createT = throw new IllegalStateException(s"The molecule $lastAccessedMolecule does not exist and cannot create empty concentration")
+  override def createT = null.asInstanceOf[T]
 
   override def getConcentration(mol: Molecule): T = {
     lastAccessedMolecule = mol

--- a/alchemist-incarnation-scafi/src/test/resources/empty_molecule_initialization.yml
+++ b/alchemist-incarnation-scafi/src/test/resources/empty_molecule_initialization.yml
@@ -1,0 +1,9 @@
+incarnation: scafi
+
+deployments:
+  - type: Point
+    parameters: [4,4]
+    programs:
+      - time-distribution: 1
+        type: Event
+        actions: { type: it.unibo.alchemist.scafi.test.FooAction, parameters: [ "foo" ] }

--- a/alchemist-incarnation-scafi/src/test/scala/it/unibo/alchemist/scafi/test/FooAction.scala
+++ b/alchemist-incarnation-scafi/src/test/scala/it/unibo/alchemist/scafi/test/FooAction.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2010-2021, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.scafi.test
+
+import it.unibo.alchemist.model.implementations.actions.AbstractAction
+import it.unibo.alchemist.model.implementations.molecules.SimpleMolecule
+import it.unibo.alchemist.model.interfaces.{Action, Context, Node, Reaction}
+
+class FooAction(val node: Node[Any], moleculeName: String) extends AbstractAction[Any](node) {
+  override def cloneAction(node: Node[Any], reaction: Reaction[Any]): Action[Any] = new FooAction(node, moleculeName)
+  override def execute(): Unit = node.getConcentration(new SimpleMolecule(moleculeName))
+  override def getContext: Context = Context.LOCAL
+}

--- a/alchemist-incarnation-scafi/src/test/scala/it/unibo/alchemist/scafi/test/TestInSimulator.scala
+++ b/alchemist-incarnation-scafi/src/test/scala/it/unibo/alchemist/scafi/test/TestInSimulator.scala
@@ -44,7 +44,6 @@ class TestInSimulator[P <: Position[P]] extends AnyFunSuite with Matchers {
     }
   }
 
-
   test("Gradient"){
     val env = testNoVar[Any]("/test_gradient.yml")
     env.getNodes.iterator().asScala.foreach(node => {
@@ -86,6 +85,10 @@ class TestInSimulator[P <: Position[P]] extends AnyFunSuite with Matchers {
     testNoVar("/test_multiple_program.yml")
   }
 
+  test("Empty molecule concentration") {
+    testNoVar("/empty_molecule_initialization.yml")
+  }
+  
   private def testNoVar[T](resource: String, maxSteps: Long = 1000): Environment[T, P] = {
     testLoading(resource, Map(), maxSteps)
   }


### PR DESCRIPTION
ScaFi incarnation currently throws an exception in `createT` method. 

However, in this way, we cannot easily use some action (for instance, [MoveToTarget](https://github.com/AlchemistSimulator/Alchemist/blob/4c167bc9eb3f3925936f62b5a620e5f15deee037/alchemist-implementationbase/src/main/java/it/unibo/alchemist/model/implementations/actions/MoveToTarget.java#L32) that uses [FollowTarget](https://github.com/AlchemistSimulator/Alchemist/blob/4c167bc9eb3f3925936f62b5a620e5f15deee037/alchemist-implementationbase/src/main/java/it/unibo/alchemist/model/implementations/movestrategies/target/FollowTarget.java#L74) and it assumes that the target molecule could be null).

Furthermore, [ProtelisNode](https://github.com/AlchemistSimulator/Alchemist/blob/4c167bc9eb3f3925936f62b5a620e5f15deee037/alchemist-incarnation-protelis/src/main/java/it/unibo/alchemist/model/implementations/nodes/ProtelisNode.java#L56) implements this method returning null, so I think that also ScaFiNode should return null accordingly.