### PR TITLE
fix(logging): the simulator only displays warning and erros by default (fixes #1038)

### DIFF
--- a/alchemist-full/build.gradle.kts
+++ b/alchemist-full/build.gradle.kts
@@ -1,3 +1,5 @@
+import Libs.alchemist
+
 /*
  * Copyright (C) 2010-2019, Danilo Pianini and contributors listed in the main(project"s alchemist/build.gradle file.
  *
@@ -12,6 +14,7 @@ dependencies {
         runtimeOnly(it)
     }
     testImplementation(rootProject)
+    testImplementation(alchemist("euclidean-geometry"))
 }
 
 plugins {

--- a/alchemist-full/src/test/kotlin/it/unibo/alchemist/model/implementations/environments/LoggingEnvironment.kt
+++ b/alchemist-full/src/test/kotlin/it/unibo/alchemist/model/implementations/environments/LoggingEnvironment.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.model.implementations.environments.it.unibo.alchemist.model.implementations.environments
+
+import it.unibo.alchemist.model.implementations.environments.Continuous2DEnvironment
+import it.unibo.alchemist.model.implementations.positions.Euclidean2DPosition
+import it.unibo.alchemist.model.interfaces.Incarnation
+import org.slf4j.LoggerFactory
+
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+class LoggingEnvironment(
+    incarnation: Incarnation<Any, Euclidean2DPosition>
+) : Continuous2DEnvironment<Any>(incarnation) {
+
+    init {
+        val logger = LoggerFactory.getLogger(LoggingEnvironment::class.java)
+        logger.trace("TRACE MESSAGE")
+        logger.debug("DEBUG MESSAGE")
+        logger.info("INFO MESSAGE")
+        logger.warn("WARN MESSAGE")
+        logger.error("ERROR MESSAGE")
+    }
+}

--- a/alchemist-full/src/test/kotlin/it/unibo/alchemist/test/TestLaunchViaMain.kt
+++ b/alchemist-full/src/test/kotlin/it/unibo/alchemist/test/TestLaunchViaMain.kt
@@ -10,7 +10,15 @@
 package it.unibo.alchemist.test
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.string.beEmpty
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import it.unibo.alchemist.Alchemist
+import org.slf4j.event.Level
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets.UTF_8
 
 /**
  * Tests the execution of the Alchemist main. It triggers a VM exit and must get launched in its own JVM.
@@ -19,4 +27,44 @@ class TestLaunchViaMain : StringSpec({
     "A simple simulation should be executable in headless mode" {
         Alchemist.main(arrayOf("-y", "simulation.yml", "-hl", "-t", "2"))
     }
-})
+
+    "The default logging level should be warn" {
+        option(null) shouldLogAtLevel Level.WARN
+    }
+
+    "Verbosity levels should be controllable via command line options" {
+        launchWithLoggingOption("-qq") should beEmpty()
+        option("-q") shouldLogAtLevel Level.ERROR
+        option("-v") shouldLogAtLevel Level.INFO
+        option("-vv") shouldLogAtLevel Level.DEBUG
+        option("-vvv") shouldLogAtLevel Level.TRACE
+    }
+}) {
+    companion object {
+
+        private fun launchWithLoggingOption(option: String?): String {
+            val writer = ByteArrayOutputStream()
+            val systemOut = System.out
+            System.setOut(PrintStream(writer, true, UTF_8))
+            val loggerOptions = if (option == null) arrayOf() else arrayOf(option)
+            Alchemist.main(arrayOf("-y", "logging.yml", "-hl") + loggerOptions)
+            System.setOut(systemOut)
+            return writer.toString(UTF_8)
+        }
+
+        private class LevelContext(val option: String? = null) {
+            infix fun shouldLogAtLevel(level: Level) {
+                val output = launchWithLoggingOption(option)
+                Level.values().forEach {
+                    if (it.ordinal <= level.ordinal) {
+                        output shouldContain it.name
+                    } else {
+                        output shouldNotContain it.name
+                    }
+                }
+            }
+        }
+
+        private fun option(option: String? = null): LevelContext = LevelContext(option)
+    }
+}

--- a/alchemist-full/src/test/resources/logging.yml
+++ b/alchemist-full/src/test/resources/logging.yml
@@ -1,0 +1,4 @@
+incarnation: protelis
+
+environment:
+  type: LoggingEnvironment

--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -1,7 +1,0 @@
-appender("STDOUT", ConsoleAppender) {
-    encoder(PatternLayoutEncoder) {
-        pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{20} - %msg%n"
-    }
-}
-logger("org.reflections.Reflections", OFF)
-root(WARN, ["STDOUT"])


### PR DESCRIPTION
Logback dropped support for Groovy in response to [CVE-2021-42550](https://cve.report/CVE-2021-42550) (aka [LOGBACK-1591](https://jira.qos.ch/browse/LOGBACK-1591)). Alchemist relied on a Groovy configuration file, and the update caused bug #1038.
This PR the aforementioned bug by dropping the Groovy configuration and configuring Logback forcibly via Kotlin at launch (sigh).
A regression test has been added.