### PR TITLE
feat: default protelis incarnation

### DIFF
--- a/alchemist-incarnation-protelis/src/main/java/it/unibo/alchemist/model/ProtelisIncarnation.java
+++ b/alchemist-incarnation-protelis/src/main/java/it/unibo/alchemist/model/ProtelisIncarnation.java
@@ -71,11 +71,17 @@ import java.util.stream.Collectors;
  */
 public final class ProtelisIncarnation<P extends Position<P>> implements Incarnation<Object, P> {
 
+    private static final Logger L = LoggerFactory.getLogger(ProtelisIncarnation.class);
+
     /**
      * The name that can be used in a property to refer to the extracted value.
      */
     public static final String VALUE_TOKEN = "<value>";
-    private static final Logger L = LoggerFactory.getLogger(ProtelisIncarnation.class);
+    /**
+     * Statically-referenceable instance. This incarnation *can* work as a singleton, and doing so may save some
+     * memory. However, it is not strictly a singleton (multiple instances do not do harm).
+     */
+    public static final ProtelisIncarnation<?> INSTANCE = new ProtelisIncarnation<>();
     private final LoadingCache<CacheKey, SynchronizedVM> cache = CacheBuilder
             .newBuilder()
             .expireAfterAccess(10, TimeUnit.MINUTES)

--- a/alchemist-incarnation-protelis/src/main/kotlin/it/unibo/alchemist/model/implementations/actions/RunProtelisProgram.kt
+++ b/alchemist-incarnation-protelis/src/main/kotlin/it/unibo/alchemist/model/implementations/actions/RunProtelisProgram.kt
@@ -192,7 +192,7 @@ class RunProtelisProgram<P : Position<P>> private constructor(
         node.asProperty(),
         reaction,
         originalProgram = originalProgram,
-        program = program,
+        program = program, // TODO: this is broken until https://github.com/Protelis/Protelis/pull/676 gets merged
         retentionTime = retentionTime,
         packetLossDistance = packetLossDistance,
     )

--- a/alchemist-incarnation-protelis/src/main/kotlin/it/unibo/alchemist/model/implementations/properties/ProtelisDevice.kt
+++ b/alchemist-incarnation-protelis/src/main/kotlin/it/unibo/alchemist/model/implementations/properties/ProtelisDevice.kt
@@ -25,7 +25,7 @@ class ProtelisDevice @JvmOverloads constructor(
     /**
      * A reference to the current incarnation.
      */
-    val incarnation: ProtelisIncarnation<*>,
+    val incarnation: ProtelisIncarnation<*> = ProtelisIncarnation.INSTANCE,
     override val node: Node<Any>,
     networkManagers: Map<RunProtelisProgram<*>, AlchemistNetworkManager> = mapOf()
 ) : NodeProperty<Any>, ExecutionEnvironment, DeviceUID {


### PR DESCRIPTION
Make `ProtelisDevice` usable even when there is a different incarnation being used.