### PR TITLE
fix(physics): fix physics update rate

### DIFF
--- a/alchemist-physics/src/main/kotlin/it/unibo/alchemist/model/implementations/environments/EnvironmentWithDynamics.kt
+++ b/alchemist-physics/src/main/kotlin/it/unibo/alchemist/model/implementations/environments/EnvironmentWithDynamics.kt
@@ -117,7 +117,7 @@ class EnvironmentWithDynamics<T> @JvmOverloads constructor(
     } ?: this.origin
 
     override fun updatePhysics(elapsedTime: Double) {
-        world.update(elapsedTime)
+        world.update(elapsedTime, Int.MAX_VALUE)
     }
 
     override fun getPosition(node: Node<T>): Euclidean2DPosition = nodeToBody[node]?.position


### PR DESCRIPTION
I've found the reason why the simulation seemed to be slower after the global reaction introduction.
Here's the [link](https://github.com/dyn4j/dyn4j/issues/37) to the issue on the physics engine's repo with the explanation.
