### PR TITLE
build: enable support for Kotlin multiplatform subprojects

### DIFF
--- a/alchemist-full/build.gradle.kts
+++ b/alchemist-full/build.gradle.kts
@@ -23,3 +23,7 @@ dependencies {
 application {
     mainClass.set("it.unibo.alchemist.Alchemist")
 }
+
+tasks.withType<AbstractArchiveTask> {
+    duplicatesStrategy = DuplicatesStrategy.WARN
+}

--- a/alchemist-full/build.gradle.kts
+++ b/alchemist-full/build.gradle.kts
@@ -1,5 +1,3 @@
-import Libs.alchemist
-
 /*
  * Copyright (C) 2010-2019, Danilo Pianini and contributors listed in the main(project"s alchemist/build.gradle file.
  *
@@ -7,13 +5,17 @@ import Libs.alchemist
  * GNU General Public License, with a linking exception,
  * as described in the file LICENSE in the Alchemist distribution"s top directory.
  */
+
+import Libs.alchemist
+import Util.isMultiplatform
+
 plugins {
     application
 }
 
 dependencies {
     runtimeOnly(rootProject)
-    rootProject.subprojects.filterNot { it == project }.forEach {
+    rootProject.subprojects.filterNot { it == project || it.isMultiplatform }.forEach {
         runtimeOnly(it)
     }
     testImplementation(rootProject)

--- a/alchemist-full/build.gradle.kts
+++ b/alchemist-full/build.gradle.kts
@@ -15,8 +15,12 @@ plugins {
 
 dependencies {
     runtimeOnly(rootProject)
-    rootProject.subprojects.filterNot { it == project || it.isMultiplatform }.forEach {
-        runtimeOnly(it)
+    rootProject.subprojects.filterNot { it == project }.forEach {
+        if (it.isMultiplatform) {
+            runtimeOnly(project(path = ":${it.name}", configuration = "default"))
+        } else {
+            runtimeOnly(it)
+        }
     }
     testImplementation(rootProject)
     testImplementation(alchemist("euclidean-geometry"))

--- a/buildSrc/src/main/kotlin/Util.kt
+++ b/buildSrc/src/main/kotlin/Util.kt
@@ -119,4 +119,11 @@ object Util {
      * Directly accesses the plugin id.
      */
     val Provider<PluginDependency>.id get() = get().pluginId
+
+    /**
+     * Checks if the project contains a property with key "multiplatform" and if its value is true.
+     * @return true if the property exists and it is true, false otherwhise.
+     */
+    val Project.isMultiplatform get() =
+        this.hasProperty("multiplatform") && this.property("multiplatform") == "true"
 }

--- a/buildSrc/src/main/kotlin/Util.kt
+++ b/buildSrc/src/main/kotlin/Util.kt
@@ -121,9 +121,10 @@ object Util {
     val Provider<PluginDependency>.id get() = get().pluginId
 
     /**
-     * Checks if the project contains a property with key "multiplatform" and if its value is true.
-     * @return true if the property exists and it is true, false otherwhise.
+     *  Check if the project contains at least one of the multiplatform most common sourceSets,
+     *  if so, assume it is a multiplatform project.
      */
-    val Project.isMultiplatform get() =
-        this.hasProperty("multiplatform") && this.property("multiplatform") == "true"
+    val Project.isMultiplatform get() = listOf("common", "jvm", "js", "native").any {
+        projectDir.resolve("src/${it}Main").exists()
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gitSemVer = "org.danilopianini.git-sensitive-semantic-versioning:0.3.0"
 hugo = "io.github.fstaudt.hugo:0.4.0"
 java-qa = "org.danilopianini.gradle-java-qa:0.40.0"
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-qa = "org.danilopianini.gradle-kotlin-qa:0.27.1"
 multiJvmTesting = "org.danilopianini.multi-jvm-test-plugin:0.4.9"


### PR DESCRIPTION
It will be possible to include a multiplatform subproject in the repository using the kotlin("multiplatform") plugin and a "multiplatform" property.