### PR TITLE
ci: add uploadJvm and uploadJs to release

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,7 +27,7 @@ jobs:
             publishKotlinOSSRHPublicationToGithubRepository \
             release \
             shadowJar \
-            uploadKotlinOSSRH uploadKotlinMultiplatform \
+            uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs \
             --dry-run
             "
             eval $COMMAND || eval $COMMAND
@@ -58,9 +58,9 @@ jobs:
           build-command: true
           check-command: true
           deploy-command: >-
-            ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform close --parallel ||
-            ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform close --parallel ||
-            ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform close --parallel
+            ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs close --parallel ||
+            ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs close --parallel ||
+            ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs close --parallel
           java-version: 11
           should-run-codecov: false
           should-deploy: true

--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -128,3 +128,13 @@ publishing.publications {
         }
     }
 }
+
+publishing {
+    publications {
+        publications.withType<MavenPublication>().configureEach {
+            if ("OSSRH" !in name) {
+                artifact(tasks.javadocJar)
+            }
+        }
+    }
+}

--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -128,13 +128,3 @@ publishing.publications {
         }
     }
 }
-
-publishing {
-    publications {
-        publications.withType<MavenPublication>().configureEach {
-            if ("OSSRH" !in name) {
-                artifact(tasks.javadocJar)
-            }
-        }
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,6 +134,15 @@ allprojects {
             dependsOn(dokka)
             from(dokka.outputDirectory)
         }
+        publishing {
+            publications {
+                publications.withType<MavenPublication>().configureEach {
+                    if ("OSSRH" !in name) {
+                        artifact(tasks.javadocJar)
+                    }
+                }
+            }
+        }
     }
 
     // COMPILE

--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,8 @@ git -C build/website/ add . || exit 1
 git -C build/website/ commit -m "chore: update website to version \${nextRelease.version}" || exit 2
 git -C build/website/ push || exit 3
 ./gradlew shadowJar --parallel || ./gradlew shadowJar --parallel || exit 4
-./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel exit 5
+RELEASE_ON_CENTRAL="./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel"
+eval "$RELEASE_ON_CENTRAL" || eval "$RELEASE_ON_CENTRAL" || eval "$RELEASE_ON_CENTRAL" || exit 5
 ./gradlew publishKotlinOSSRHPublicationToGithubRepository --continue || true
 `
 var config = require('semantic-release-preconfigured-conventional-commits');

--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,7 @@ git -C build/website/ add . || exit 1
 git -C build/website/ commit -m "chore: update website to version \${nextRelease.version}" || exit 2
 git -C build/website/ push || exit 3
 ./gradlew shadowJar --parallel || ./gradlew shadowJar --parallel || exit 4
-./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform release --parallel exit 5
+./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel exit 5
 ./gradlew publishKotlinOSSRHPublicationToGithubRepository --continue || true
 `
 var config = require('semantic-release-preconfigured-conventional-commits');


### PR DESCRIPTION
I did some extra researches just to be 100% sure and differently from what I specified in the email, uploadAll seems to include some fatJars. This is caused by uploadJavaOSSRH. Since we don't need this last task, I added the uploadJvm and uploadJs tasks instead.