### PR TITLE
docs(website): add safeHTML into import shortcode to avoid html escapes

### DIFF
--- a/site/layouts/shortcodes/import.html
+++ b/site/layouts/shortcodes/import.html
@@ -1,5 +1,5 @@
 {{- $content := readFile (.Get 0) | htmlUnescape -}}
-{{- $content -}}<!--
+{{- $content | safeHTML -}}<!--
   ~ Copyright (C) 2010-2022, Danilo Pianini and contributors
   ~ listed, for each module, in the respective subproject's build.gradle.kts file.
   ~


### PR DESCRIPTION
The `import` shortcode doesn't work currently, since the page imported show all the escape chars.
For instance, look here: https://alchemistsimulator.github.io/tutorials/scafi/index.html#what-is-inside
![image](https://user-images.githubusercontent.com/23448811/208308744-7060c37e-10b3-4eac-9d50-28bd67393118.png)


`safeHTML` solves the problem.