### PR TITLE
feat(web-renderer): add the surrogate classes and some serializazion utility

### DIFF
--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/serialization/JsonFormat.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/serialization/JsonFormat.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.serialization
+
+import it.unibo.alchemist.common.model.serialization.SerializationModules.concentrationModule
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import kotlinx.serialization.json.Json
+
+/**
+ * An instance of [Json] that can be used to serialize and deserialize some concentration classes using open
+ * polymorphism.
+ */
+val jsonFormat = Json {
+    serializersModule = concentrationModule
+}
+
+/**
+ * Encode the EnvironmentSurrogate to a JSON string using the [EnvironmentSurrogate.polymorphicSerializer] to serialize
+ * the concentrations.
+ * @param env the [EnvironmentSurrogate] to encode.
+ * @param <TS> the type of concentration surrogate.
+ * @param <PS> the type of [PositionSurrogate].
+ * @return the JSON string.
+ */
+inline fun <reified TS, reified PS> Json.encodeEnvironmentSurrogate(env: EnvironmentSurrogate<TS, PS>): String
+    where TS : Any, PS : PositionSurrogate = this.encodeToString(EnvironmentSurrogate.polymorphicSerializer(), env)
+
+/**
+ * Decode the JSON string to an [EnvironmentSurrogate] using the [EnvironmentSurrogate.polymorphicSerializer] to
+ * deserialize the concentrations.
+ * @param env the [String] to decode.
+ * @return the corresponding [EnvironmentSurrogate].
+ */
+fun Json.decodeEnvironmentSurrogate(env: String): EnvironmentSurrogate<Any, PositionSurrogate> =
+    this.decodeFromString(EnvironmentSurrogate.polymorphicSerializer(), env)

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/serialization/SerializationModules.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/serialization/SerializationModules.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.serialization
+
+import it.unibo.alchemist.common.model.surrogate.EmptyConcentrationSurrogate
+
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+
+/**
+ * Object containing the [SerializersModule]s used by the web-renderer project.
+ */
+object SerializationModules {
+
+    /**
+     * The [SerializersModule] used to serialize and deserialize all the possible Concentration types.
+     */
+    val concentrationModule = SerializersModule {
+        polymorphic(Any::class) {
+            subclass(EmptyConcentrationSurrogate::class)
+            default { EmptyConcentrationSurrogate.serializer() }
+        }
+    }
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/EmptyConcentrationSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/EmptyConcentrationSurrogate.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * An object that represents an Empty Concentration.
+ */
+@SerialName("EmptyConcentration")
+@Serializable
+object EmptyConcentrationSurrogate

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/EnvironmentSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/EnvironmentSurrogate.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Surrogate class for the [it.unibo.alchemist.model.interfaces.Environment] interface.
+ * @param dimensions the number of dimensions of the [EnvironmentSurrogate].
+ * @param nodes the nodes contained in the [EnvironmentSurrogate].
+ * @param <TS> the type of concentration.
+ * @param <PS> the type of [PositionSurrogate].
+ */
+@Serializable
+@SerialName("Environment")
+data class EnvironmentSurrogate<out TS : Any, out PS : PositionSurrogate>(
+    val dimensions: Int,
+    val nodes: List<NodeSurrogate<TS, PS>>
+) {
+    companion object {
+        /**
+         * @param <TS> the type of concentration.
+         * @param <PS> the type of [PositionSurrogate].
+         * @return an empty and uninitialized [EnvironmentSurrogate].
+         */
+        fun <TS : Any, PS : PositionSurrogate> uninitializedEnvironment(): EnvironmentSurrogate<TS, PS> =
+            EnvironmentSurrogate(-1, emptyList())
+
+        /**
+         * @return The most general polymorphic serializer for the [EnvironmentSurrogate] class, using [Any] and
+         * [PositionSurrogate] as type parameters.
+         */
+        fun polymorphicSerializer(): KSerializer<EnvironmentSurrogate<Any, PositionSurrogate>> = serializer(
+            PolymorphicSerializer(Any::class),
+            PositionSurrogate.serializer()
+        )
+    }
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/GeneralPositionSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/GeneralPositionSurrogate.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *  Surrogate class for the [it.unibo.alchemist.model.interfaces.Position] interface.
+ *  This implementation is valid for any type of position.
+ *  @param coordinates the coordinates of the [PositionSurrogate].
+ *  @param dimensions the dimensions of the [PositionSurrogate].
+ */
+@Serializable
+@SerialName("Position")
+data class GeneralPositionSurrogate(
+    override val coordinates: DoubleArray,
+    override val dimensions: Int
+) : PositionSurrogate {
+    init {
+        require(coordinates.size == dimensions) {
+            "The number of coordinates must be equal to the number of dimensions."
+        }
+    }
+
+    /**
+     * Override equals because a [DoubleArray] is present in the properties.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as PositionSurrogate
+
+        if (!coordinates.contentEquals(other.coordinates)) return false
+        if (dimensions != other.dimensions) return false
+
+        return true
+    }
+
+    /**
+     * Override hashCode because a [DoubleArray] is present in the properties.
+     */
+    override fun hashCode(): Int {
+        var result = coordinates.contentHashCode()
+        result = 31 * result + dimensions
+        return result
+    }
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/MoleculeSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/MoleculeSurrogate.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Surrogate class for the [it.unibo.alchemist.model.interfaces.Molecule] interface.
+ * @param name the name of the molecule.
+ */
+@Serializable(with = MoleculeSurrogateSerializer::class)
+data class MoleculeSurrogate(val name: String)
+
+/**
+ * Custom serializer to map a molecule to a string, as in JSON non-primitive types aren't allowed in [Map] key position.
+ */
+object MoleculeSurrogateSerializer : KSerializer<MoleculeSurrogate> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Molecule", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: MoleculeSurrogate) {
+        encoder.encodeSerializableValue(String.serializer(), value.name)
+    }
+
+    override fun deserialize(decoder: Decoder): MoleculeSurrogate {
+        val string = decoder.decodeSerializableValue(String.serializer())
+        return MoleculeSurrogate(string)
+    }
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/NodeSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/NodeSurrogate.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Surrogate class for the [it.unibo.alchemist.model.interfaces.Node] interface.
+ * Note: The position is kept by the Environment in the original structure.
+ * To improve performance and reduce the serialized [String] size, the position was moved to the node.
+ * @param id the id of the [NodeSurrogate].
+ * @param contents the mapping between [MoleculeSurrogate] and concentrations.
+ * @param position the position of the [NodeSurrogate].
+ * @param <TS> the type of concentration surrogate.
+ * @param <PS> the type of the [PositionSurrogate].
+ */
+@Serializable
+@SerialName("Node")
+data class NodeSurrogate<out TS : Any, out PS : PositionSurrogate>(
+    val id: Int,
+    val contents: Map<MoleculeSurrogate, TS>,
+    val position: PS
+)

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/Position2DSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/Position2DSurrogate.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Surrogate class for the [it.unibo.alchemist.model.interfaces.Position2D] interface.
+ * @param x the first coordinate of the position.
+ * @param y the second coordinate of the position.
+ * @param coordinates the coordinates of the [PositionSurrogate], default using x and y.
+ * @param dimensions the dimensions of the [PositionSurrogate], default to 2.
+ */
+@Serializable
+@SerialName("Position2D")
+data class Position2DSurrogate(
+    val x: Double,
+    val y: Double,
+    override val coordinates: DoubleArray = doubleArrayOf(x, y),
+    override val dimensions: Int = 2
+) : PositionSurrogate {
+
+    /**
+     * Override equals because a [DoubleArray] is present in the properties.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Position2DSurrogate
+
+        if (x != other.x) return false
+        if (y != other.y) return false
+        if (!coordinates.contentEquals(other.coordinates)) return false
+        if (dimensions != other.dimensions) return false
+
+        return true
+    }
+
+    /**
+     * Override hashCode because a [DoubleArray] is present in the properties.
+     */
+    override fun hashCode(): Int {
+        var result = x.hashCode()
+        result = 31 * result + y.hashCode()
+        result = 31 * result + coordinates.contentHashCode()
+        result = 31 * result + dimensions
+        return result
+    }
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/PositionSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/PositionSurrogate.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.Serializable
+
+/**
+ *  Surrogate interface for the [it.unibo.alchemist.model.interfaces.Position] interface.
+ *  Note: by using the sealed keyword any subclass of [PositionSurrogate] can be serialized and deserialized
+ *  automatically using a polymorphic serializer.
+ */
+@Serializable
+sealed interface PositionSurrogate {
+    /**
+     * The coordinates of the position.
+     */
+    val coordinates: DoubleArray
+
+    /**
+     * The number of dimensions of the position.
+     */
+    val dimensions: Int
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/StatusSurrogate.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/surrogate/StatusSurrogate.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Multiplatform enum to use the [it.unibo.alchemist.core.interfaces.Status] outside a jvm.
+ */
+@SerialName("Status")
+@Serializable
+enum class StatusSurrogate {
+
+    /**
+     * The simulation is being initialized.
+     */
+    INIT,
+
+    /**
+     * The simulation is ready to be started.
+     */
+    READY,
+
+    /**
+     * The simulation is paused. It can be resumed.
+     */
+    PAUSED,
+
+    /**
+     * The simulation is currently running.
+     */
+    RUNNING,
+
+    /**
+     * The simulation is stopped. It is no longer possible to resume it.
+     */
+    TERMINATED
+}

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/serialization/JsonFormatTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/serialization/JsonFormatTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.serialization
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.surrogate.EmptyConcentrationSurrogate
+import kotlinx.serialization.PolymorphicSerializer
+
+class JsonFormatTest : StringSpec({
+
+    "Polymorphic serialization and deserialization should work for EmptyConcentration" {
+        val concentration: Any = EmptyConcentrationSurrogate
+        val serialized = jsonFormat.encodeToString(PolymorphicSerializer(Any::class), concentration)
+        serialized.contains("type") shouldBe true
+        val deserialized = jsonFormat.decodeFromString(PolymorphicSerializer(Any::class), serialized)
+        deserialized shouldBe EmptyConcentrationSurrogate
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/EmptyConcentrationTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/EmptyConcentrationTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+
+@OptIn(ExperimentalSerializationApi::class)
+class EmptyConcentrationTest : StringSpec({
+
+    val emptyConcentration = EmptyConcentrationSurrogate
+
+    "EmptyConcentration should be serialized correctly" {
+        EmptyConcentrationSurrogate.serializer().descriptor.serialName shouldBe "EmptyConcentration"
+        val ser = jsonFormat.encodeToString(emptyConcentration)
+        val des: EmptyConcentrationSurrogate = jsonFormat.decodeFromString(ser)
+        des shouldBe emptyConcentration
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/EnvironmentSurrogateTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/EnvironmentSurrogateTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.serialization.decodeEnvironmentSurrogate
+import it.unibo.alchemist.common.model.serialization.encodeEnvironmentSurrogate
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.builtins.serializer
+
+@OptIn(ExperimentalSerializationApi::class)
+class EnvironmentSurrogateTest : StringSpec({
+
+    val position = Position2DSurrogate(5.6, 8.42)
+
+    val nodesListSet = listOf(
+        NodeSurrogate(
+            0,
+            mapOf(
+                MoleculeSurrogate("test-0") to EmptyConcentrationSurrogate,
+                MoleculeSurrogate("test-1") to EmptyConcentrationSurrogate
+            ),
+            position
+        ),
+        NodeSurrogate(
+            1,
+            mapOf(MoleculeSurrogate("test-2") to EmptyConcentrationSurrogate),
+            position
+        )
+    )
+
+    val envSurrogate: EnvironmentSurrogate<Any, PositionSurrogate> = EnvironmentSurrogate(2, nodesListSet)
+
+    "EnvironmentSurrogate should have the correct dimensions" {
+        envSurrogate.dimensions shouldBe 2
+    }
+
+    "EnvironmentSurrogate should have the correct nodes" {
+        envSurrogate.nodes.size shouldBe 2
+        envSurrogate.nodes shouldBe nodesListSet
+    }
+
+    "EnvironmentSurrogate serialization and deserialization should work" {
+        EnvironmentSurrogate.serializer(
+            Int.serializer(),
+            PositionSurrogate.serializer()
+        ).descriptor.serialName shouldBe "Environment"
+        val serialized = jsonFormat.encodeEnvironmentSurrogate(envSurrogate)
+        val deserializedPolymorphic = jsonFormat.decodeEnvironmentSurrogate(serialized)
+        deserializedPolymorphic shouldBe envSurrogate
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/GeneralPositionSurrogateTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/GeneralPositionSurrogateTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@OptIn(ExperimentalSerializationApi::class)
+class GeneralPositionSurrogateTest : StringSpec({
+
+    val generalPositionSurrogate: PositionSurrogate = GeneralPositionSurrogate(
+        doubleArrayOf(5.0, 1.1, 6.0),
+        3
+    )
+
+    "GeneralPositionSurrogate should have the correct number of coordinates" {
+        generalPositionSurrogate.coordinates.size shouldBe 3
+    }
+
+    "GeneralPositionSurrogate should have the correct number of dimensions" {
+        generalPositionSurrogate.dimensions shouldBe 3
+    }
+
+    "GeneralPositionSurrogate should have the correct coordinates" {
+        generalPositionSurrogate.coordinates[0] shouldBe 5.0
+        generalPositionSurrogate.coordinates[1] shouldBe 1.1
+        generalPositionSurrogate.coordinates[2] shouldBe 6.0
+    }
+
+    "GeneralPositionSurrogate should fail on creation if coordinates size is different from dimensions" {
+        shouldThrow<IllegalArgumentException> {
+            GeneralPositionSurrogate(doubleArrayOf(5.0, 1.1), 3)
+        }
+    }
+
+    "GeneralPositionSurrogate hashCode and equals should work as expected" {
+        val pos1 = GeneralPositionSurrogate(doubleArrayOf(1.0, 2.8, 3.0), 3)
+        val pos2 = GeneralPositionSurrogate(doubleArrayOf(1.0, 2.8, 3.0), 3)
+        val pos3 = GeneralPositionSurrogate(doubleArrayOf(1.0), 1)
+        pos1.hashCode() shouldBe pos2.hashCode()
+        pos1.hashCode() shouldNotBe pos3.hashCode()
+        pos2.hashCode() shouldNotBe pos3.hashCode()
+        (pos1 == pos2) shouldBe true
+        (pos1 == pos3) shouldBe false
+        (pos2 == pos3) shouldBe false
+    }
+
+    "GeneralPositionSurrogate should be serialized and deserialized correctly" {
+        GeneralPositionSurrogate.serializer().descriptor.serialName shouldBe "Position"
+        val serialized = Json.encodeToString(generalPositionSurrogate)
+        val deserializedPolymorphic = Json.decodeFromString<PositionSurrogate>(serialized)
+        deserializedPolymorphic shouldBe generalPositionSurrogate
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/MoleculeSurrogateTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/MoleculeSurrogateTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+
+@OptIn(ExperimentalSerializationApi::class)
+class MoleculeSurrogateTest : StringSpec({
+
+    val moleculeSurrogate = MoleculeSurrogate("molecule")
+
+    "MoleculeSurrogate should have the correct name" {
+        moleculeSurrogate.name shouldBe "molecule"
+    }
+
+    "MoleculeSurrogate should be serialized and deserialized correctly" {
+        MoleculeSurrogate.serializer().descriptor.serialName shouldBe "Molecule"
+        val serialized = jsonFormat.encodeToString(moleculeSurrogate)
+        serialized shouldBe "\"molecule\""
+        val deserialized: MoleculeSurrogate = jsonFormat.decodeFromString(serialized)
+        deserialized shouldBe moleculeSurrogate
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/NodeSurrogateTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/NodeSurrogateTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@OptIn(ExperimentalSerializationApi::class)
+class NodeSurrogateTest : StringSpec({
+
+    val mapping = mapOf(MoleculeSurrogate("test-0") to 0, MoleculeSurrogate("test-1") to 1)
+
+    val nodePosition = Position2DSurrogate(5.6, 1.2)
+
+    val nodeSurrogate = NodeSurrogate(29, mapping, nodePosition)
+
+    "NodeSurrogate should have the correct id" {
+        nodeSurrogate.id shouldBe 29
+    }
+
+    "NodeSurrogate should have contents" {
+        nodeSurrogate.contents[MoleculeSurrogate("test-0")] shouldBe 0
+        nodeSurrogate.contents[MoleculeSurrogate("test-1")] shouldBe 1
+        nodeSurrogate.contents.size shouldBe 2
+    }
+
+    "NodeSurrogate should have a position" {
+        nodeSurrogate.position shouldBe nodePosition
+    }
+
+    "NodeSurrogate should be serialized correctly" {
+        NodeSurrogate.serializer(
+            Int.serializer(),
+            PositionSurrogate.serializer()
+        ).descriptor.serialName shouldBe "Node"
+        val serialized = Json.encodeToString(nodeSurrogate)
+        val deserialized: NodeSurrogate<Int, Position2DSurrogate> = Json.decodeFromString(serialized)
+        deserialized shouldBe nodeSurrogate
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/Position2DSurrogateTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/Position2DSurrogateTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@OptIn(ExperimentalSerializationApi::class)
+class Position2DSurrogateTest : StringSpec({
+
+    val positionSurrogate: PositionSurrogate = Position2DSurrogate(5.012345, 1.0000000001)
+
+    "Position2DSurrogate should have the correct number of coordinates" {
+        positionSurrogate.coordinates.size shouldBe 2
+    }
+
+    "Position2DSurrogate should have the correct number of dimensions" {
+        positionSurrogate.dimensions shouldBe 2
+    }
+
+    "Position2DSurrogate should have the correct coordinates" {
+        positionSurrogate.coordinates[0] shouldBe 5.012345
+        positionSurrogate.coordinates[1] shouldBe 1.0000000001
+    }
+
+    "Position2DSurrogate hashCode and equals should work as expected" {
+        val pos1 = Position2DSurrogate(1.0, 2.8)
+        val pos2 = Position2DSurrogate(1.0, 2.8)
+        val pos3 = Position2DSurrogate(2.0, 2.8)
+        pos1.hashCode() shouldBe pos2.hashCode()
+        pos1.hashCode() shouldNotBe pos3.hashCode()
+        pos2.hashCode() shouldNotBe pos3.hashCode()
+        (pos1 == pos2) shouldBe true
+        (pos1 == pos3) shouldBe false
+        (pos2 == pos3) shouldBe false
+    }
+
+    "Position2DSurrogate should be serialized correctly" {
+        Position2DSurrogate.serializer().descriptor.serialName shouldBe "Position2D"
+        val serialized = Json.encodeToString(positionSurrogate)
+        val deserializedPolymorphic = Json.decodeFromString<PositionSurrogate>(serialized)
+        deserializedPolymorphic shouldBe positionSurrogate
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/StatusSurrogateTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/surrogate/StatusSurrogateTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model.surrogate
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+
+class StatusSurrogateTest : StringSpec({
+
+    val listOfValues = listOf(
+        StatusSurrogate.INIT,
+        StatusSurrogate.READY,
+        StatusSurrogate.PAUSED,
+        StatusSurrogate.RUNNING,
+        StatusSurrogate.TERMINATED
+    )
+
+    "StatusSurrogate are just INIT, READY, PAUSED, RUNNING and TERMINATED" {
+        val statuses = StatusSurrogate.values()
+        statuses.size shouldBe 5
+        statuses.map { it }.containsAll(listOfValues) shouldBe true
+    }
+
+    "StatusSurrogate should be serializable and deserializable" {
+        listOfValues.forEach {
+            val ser = jsonFormat.encodeToString(it)
+            val des: StatusSurrogate = jsonFormat.decodeFromString(ser)
+            it shouldBe des
+        }
+    }
+})


### PR DESCRIPTION
Most of the model of the web-renderer project is in this pull request. Every surrogate class is carefully tested, especially for  serialization and deserialization.

PS: notify me if the PR is too big, it seems like a lot of code but the classes are pretty small and simple. 