### PR TITLE
feat(web-renderer): add toSurrogates mapping functions

### DIFF
--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -61,6 +61,9 @@ kotlin {
                 implementation(libs.kotest.assertions)
                 implementation(libs.kotest.runner)
                 implementation(libs.ktor.server.test.host)
+                implementation(alchemist("euclidean-geometry"))
+                implementation(alchemist("implementationbase"))
+                implementation(alchemist("test"))
             }
         }
         val jsMain by getting {

--- a/alchemist-web-renderer/src/commonTest/resources/yaml/sapere.yml
+++ b/alchemist-web-renderer/src/commonTest/resources/yaml/sapere.yml
@@ -1,0 +1,22 @@
+#Copyright (C) 2010-2022, Danilo Pianini and contributors
+#listed, for each module, in the respective subproject's build.gradle.kts file.
+#
+#This file is part of Alchemist, and is distributed under the terms of the
+#GNU General Public License, with a linking exception,
+#as described in the file LICENSE in the Alchemist distribution's top directory.
+
+incarnation: sapere
+
+network-model:
+  type: ConnectWithinDistance
+  parameters: [0.5]
+
+deployments:
+  type: Grid
+  parameters: [-5, -5, 5, 5, 0.25, 0.25, 0.1, 0.1]
+  contents: # A description of what will be included in the node
+    - molecule: hello # Everywhere
+    - in: # Restrict the area to...
+        type: Rectangle # ...a class implementing Shape with this name...
+        parameters: [-1, -1, 2, 2] # ...which can get built with these parameters
+      molecule: token # Molecule to inject

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToConcentrationSurrogate.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToConcentrationSurrogate.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import it.unibo.alchemist.common.model.surrogate.EmptyConcentrationSurrogate
+
+/**
+ * A set of functions to map the concentrations to the corresponding surrogate classes.
+ */
+object ToConcentrationSurrogate {
+
+    /**
+     * @return A function that maps any object to an [EmptyConcentrationSurrogate].
+     */
+    val toEmptyConcentration: (Any) -> EmptyConcentrationSurrogate = {
+        EmptyConcentrationSurrogate
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToEnvironmentSurrogate.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToEnvironmentSurrogate.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import it.unibo.alchemist.model.interfaces.Environment
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.server.surrogates.utility.ToPositionSurrogate.toSuitablePositionSurrogate
+
+/**
+ * A function that maps an [Environment] to its surrogate class ([EnvironmentSurrogate]).
+ * @param <T> the original type of the concentration.
+ * @param <P> the original type of the position.
+ * @param <TS> the surrogate type of the concentration.
+ * @param <PS> the surrogate type of the position.
+ * @param toConcentrationSurrogate the mapping function from <T> to <TS>.
+ * @param toPositionSurrogate the mapping function from <P> to <PS>.
+ */
+fun <T, P, TS, PS> Environment<T, P>.toEnvironmentSurrogate(
+    toConcentrationSurrogate: (T) -> TS,
+    toPositionSurrogate: (P) -> PS
+): EnvironmentSurrogate<TS, PS>
+    where TS : Any, P : Position<out P>, PS : PositionSurrogate =
+    EnvironmentSurrogate(
+        dimensions,
+        nodes.map {
+            it.toNodeSurrogate<T, P, TS, PS>(this, toConcentrationSurrogate, toPositionSurrogate)
+        }
+    )
+
+/**
+ * A function that maps an [Environment] to its surrogate class ([EnvironmentSurrogate]). Use the
+ * [toSuitablePositionSurrogate] strategy for [PositionSurrogate] mapping.
+ * @param <T> the original type of the concentration.
+ * @param <P> the original type of the position.
+ * @param <TS> the surrogate type of the concentration.
+ * @param toConcentrationSurrogate the mapping function from <T> to <TS>.
+ */
+fun <T, P, TS> Environment<T, P>.toEnvironmentSurrogate(
+    toConcentrationSurrogate: (T) -> TS
+): EnvironmentSurrogate<TS, PositionSurrogate>
+    where TS : Any, P : Position<out P> =
+    toEnvironmentSurrogate(
+        toConcentrationSurrogate,
+        toSuitablePositionSurrogate(this.dimensions)
+    )

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToMoleculeSurrogate.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToMoleculeSurrogate.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import it.unibo.alchemist.model.interfaces.Molecule
+import it.unibo.alchemist.common.model.surrogate.MoleculeSurrogate
+
+/**
+ * A function that maps a [it.unibo.alchemist.model.interfaces.Molecule] to its surrogate class
+ * [it.unibo.alchemist.model.surrogate.MoleculeSurrogate]
+ * @return the [it.unibo.alchemist.model.surrogate.MoleculeSurrogate] mapped starting from the
+ * [it.unibo.alchemist.model.interfaces.Molecule].
+ */
+fun Molecule.toMoleculeSurrogate(): MoleculeSurrogate = MoleculeSurrogate(name)

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToNodeSurrogate.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToNodeSurrogate.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import it.unibo.alchemist.model.interfaces.Environment
+import it.unibo.alchemist.model.interfaces.Node
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.common.model.surrogate.NodeSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+
+/**
+ * A function that maps a [it.unibo.alchemist.model.interfaces.Node] to its surrogate class
+ * [it.unibo.alchemist.model.surrogate.NodeSurrogate].
+ * @param environment the environment in which the node is. Used to collapse the position inside the node.
+ * @param toConcentrationSurrogate the mapping function from <T> to <TS>.
+ * @param toPositionSurrogate the mapping function from <P> to <PS>.
+ * @param <T> the original type of the concentration.
+ * @param <P> the original type of the position.
+ * @param <TS> the surrogate type of concentration.
+ * @param <PS> the surrogate type of position.
+ * @return the [it.unibo.alchemist.model.surrogate.NodeSurrogate] mapped starting from the
+ * [it.unibo.alchemist.model.interfaces.Node].
+ */
+fun <T, P, TS, PS> Node<T>.toNodeSurrogate(
+    environment: Environment<T, P>,
+    toConcentrationSurrogate: (T) -> TS,
+    toPositionSurrogate: (P) -> PS
+): NodeSurrogate<TS, PS>
+where TS : Any, P : Position<out P>, PS : PositionSurrogate = NodeSurrogate(
+    id,
+    contents.map { it.key.toMoleculeSurrogate() to toConcentrationSurrogate(it.value) }.toMap(),
+    toPositionSurrogate(environment.getPosition(this))
+)

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToPositionSurrogate.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToPositionSurrogate.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import it.unibo.alchemist.common.model.surrogate.GeneralPositionSurrogate
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.model.interfaces.Position2D
+import it.unibo.alchemist.common.model.surrogate.Position2DSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+
+/**
+ * A set of functions to map the Position to the corresponding surrogate classes.
+ */
+object ToPositionSurrogate {
+
+    /**
+     * @return the most suitable function to maps the [it.unibo.alchemist.model.interfaces.Position].
+     */
+    fun toSuitablePositionSurrogate(dimensions: Int): (Position<*>) -> PositionSurrogate = when (dimensions) {
+        2 -> toPosition2DSurrogate
+        else -> toGeneralPositionSurrogate
+    }
+
+    /**
+     * @return A function that maps a [it.unibo.alchemist.model.interfaces.Position] to a
+     * [it.unibo.alchemist.model.surrogate.Position2DSurrogate] surrogate class. This works only
+     * if the position is a [it.unibo.alchemist.model.interfaces.Position2D].
+     */
+    private val toPosition2DSurrogate: (Position<*>) -> Position2DSurrogate = { position ->
+        require(position is Position2D<*>)
+        Position2DSurrogate(position.x, position.y)
+    }
+
+    /**
+     * @return A function that maps a [it.unibo.alchemist.model.interfaces.Position] to its surrogate class.
+     */
+    private val toGeneralPositionSurrogate: (Position<*>) -> GeneralPositionSurrogate = { position ->
+        GeneralPositionSurrogate(position.coordinates, position.dimensions)
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToStatusSurrogate.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/surrogates/utility/ToStatusSurrogate.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+import it.unibo.alchemist.core.interfaces.Status
+
+/**
+ * Map a [Status] to [StatusSurrogate].
+ */
+fun Status.toStatusSurrogate(): StatusSurrogate = when (this) {
+    Status.INIT -> StatusSurrogate.INIT
+    Status.READY -> StatusSurrogate.READY
+    Status.PAUSED -> StatusSurrogate.PAUSED
+    Status.RUNNING -> StatusSurrogate.RUNNING
+    Status.TERMINATED -> StatusSurrogate.TERMINATED
+}

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/TestUtility.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/TestUtility.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldNotBe
+import it.unibo.alchemist.TestUtility.webRendererTestEnvironments
+import it.unibo.alchemist.model.interfaces.EuclideanEnvironment
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.model.interfaces.geometry.Vector
+import it.unibo.alchemist.testsupport.loadYamlSimulation
+import java.io.File
+
+object TestUtility {
+
+    fun <T, P> webRendererTestEnvironments(): Set<EuclideanEnvironment<T, P>> where P : Position<P>, P : Vector<P> =
+        this::class.java.classLoader.getResource("yaml")?.path?.let { path ->
+            File(path).listFiles()?.map {
+                loadYamlSimulation<T, P>("yaml/${it.name}")
+            }?.toSet()
+        } ?: emptySet()
+}
+
+class TestUtilityTest<T, P> : StringSpec({
+    "All the environment should be contained inside webRendererTestEnvironments" {
+        shouldNotThrow<NullPointerException> {
+            webRendererTestEnvironments<T, P>().size shouldNotBe 0
+        }
+    }
+}) where P : Position<P>, P : Vector<P>

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToConcentrationSurrogateTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToConcentrationSurrogateTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.surrogate.EmptyConcentrationSurrogate
+import it.unibo.alchemist.server.surrogates.utility.ToConcentrationSurrogate.toEmptyConcentration
+
+class ToConcentrationSurrogateTest : StringSpec({
+
+    "toEmptyConcentration should always return an EmptyConcentrationSurrogate" {
+        toEmptyConcentration("any") shouldBe EmptyConcentrationSurrogate
+        toEmptyConcentration(2.0) shouldBe EmptyConcentrationSurrogate
+        toEmptyConcentration(listOf("1", 2, 3.0)) shouldBe EmptyConcentrationSurrogate
+        toEmptyConcentration(mapOf(1 to "2")) shouldBe EmptyConcentrationSurrogate
+    }
+})

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToEnvironmentSurrogateTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToEnvironmentSurrogateTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.TestUtility.webRendererTestEnvironments
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.model.interfaces.geometry.Vector
+import it.unibo.alchemist.server.surrogates.utility.ToConcentrationSurrogate.toEmptyConcentration
+import it.unibo.alchemist.server.surrogates.utility.ToPositionSurrogate.toSuitablePositionSurrogate
+import org.junit.jupiter.api.fail
+
+class ToEnvironmentSurrogateTest<T, P> : StringSpec({
+
+    "ToEnvironmentSurrogate should map an Environment to an EnvironmentSurrogate" {
+        webRendererTestEnvironments<T, P>().forEach {
+            val environmentSurrogate = it.toEnvironmentSurrogate(
+                toEmptyConcentration,
+                toSuitablePositionSurrogate(it.dimensions)
+            )
+            it.dimensions shouldBe environmentSurrogate.dimensions
+            it.nodes.size shouldBe environmentSurrogate.nodes.size
+            it.nodes.forEach { node ->
+                val surrogateNode = environmentSurrogate.nodes.find { surrogateNode -> node.id == surrogateNode.id }
+                if (surrogateNode != null) {
+                    checkToNodeSurrogate(it, node, surrogateNode)
+                } else {
+                    fail("Can't find a corresponding SurrogateNode")
+                }
+            }
+        }
+    }
+})where T : Any, P : Position<P>, P : Vector<P>

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToMoleculeSurrogateTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToMoleculeSurrogateTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.surrogate.MoleculeSurrogate
+import it.unibo.alchemist.model.interfaces.Molecule
+
+class ToMoleculeSurrogateTest : StringSpec({
+
+    val molecule = Molecule { "Alchemist Molecule" }
+
+    "ToMoleculeSurrogate should map a Molecule to a MoleculeSurrogate" {
+        checkToMoleculeSurrogate(molecule, molecule.toMoleculeSurrogate())
+    }
+})
+
+fun checkToMoleculeSurrogate(molecule: Molecule, moleculeSurrogate: MoleculeSurrogate) {
+    molecule.name shouldBe moleculeSurrogate.name
+}

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToNodeSurrogateTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToNodeSurrogateTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAllKeys
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.TestUtility.webRendererTestEnvironments
+import it.unibo.alchemist.common.model.surrogate.EmptyConcentrationSurrogate
+import it.unibo.alchemist.common.model.surrogate.NodeSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.model.interfaces.Environment
+import it.unibo.alchemist.model.interfaces.Node
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.model.interfaces.geometry.Vector
+import it.unibo.alchemist.server.surrogates.utility.ToConcentrationSurrogate.toEmptyConcentration
+import it.unibo.alchemist.server.surrogates.utility.ToPositionSurrogate.toSuitablePositionSurrogate
+
+class ToNodeSurrogateTest<T, P> : StringSpec({
+    "ToNodeSurrogate should map a Node to a NodeSurrogate" {
+        webRendererTestEnvironments<T, P>().forEach {
+            val node: Node<T> = it.nodes.first()
+            val nodeSurrogate = node.toNodeSurrogate(
+                it,
+                toEmptyConcentration,
+                toSuitablePositionSurrogate(it.dimensions)
+            )
+            checkToNodeSurrogate(it, node, nodeSurrogate)
+        }
+    }
+}) where T : Any, P : Position<P>, P : Vector<P>
+
+fun <T, P, TS, PS> checkToNodeSurrogate(
+    environment: Environment<T, P>,
+    node: Node<T>,
+    nodeSurrogate: NodeSurrogate<TS, PS>
+) where T : Any, P : Position<out P>, TS : Any, PS : PositionSurrogate {
+    node.id shouldBe nodeSurrogate.id
+    node.contents.forAllKeys { molecule ->
+        val surrogateContentKey = molecule.toMoleculeSurrogate()
+        checkToMoleculeSurrogate(molecule, surrogateContentKey)
+        nodeSurrogate.contents.containsKey(surrogateContentKey)
+        nodeSurrogate.contents[surrogateContentKey] shouldBe EmptyConcentrationSurrogate
+    }
+    node.contents.size shouldBe nodeSurrogate.contents.size
+    checkToPositionSurrogate(environment.getPosition(node), nodeSurrogate.position)
+}

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToPositionSurrogateTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToPositionSurrogateTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.surrogate.GeneralPositionSurrogate
+import it.unibo.alchemist.common.model.surrogate.Position2DSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.model.implementations.positions.Euclidean2DPosition
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.model.interfaces.Position2D
+import it.unibo.alchemist.server.surrogates.utility.ToPositionSurrogate.toSuitablePositionSurrogate
+
+class ToPositionSurrogateTest : StringSpec({
+
+    "ToPositionSurrogate should map a Position to a GeneralPositionSurrogate" {
+        val alchemistPosition = object : Position<Nothing> {
+            override fun boundingBox(range: Double): List<Nothing> = error("Do not call, this is a test")
+            override val coordinates: DoubleArray get() = doubleArrayOf(1.001, 2.004, 5.67, 1.0, 2.0)
+            override fun getCoordinate(dimension: Int): Double = coordinates[dimension]
+            override val dimensions: Int get() = 5
+            override fun plus(other: DoubleArray): Nothing = error("Do not call, this is a test")
+            override fun minus(other: DoubleArray): Nothing = error("Do not call, this is a test")
+            override fun distanceTo(other: Nothing): Double = error("Do not call, this is a test")
+        }
+        val positionSurrogate = toSuitablePositionSurrogate(alchemistPosition.dimensions)(alchemistPosition)
+        if (positionSurrogate is GeneralPositionSurrogate) {
+            checkToPositionSurrogate(alchemistPosition, positionSurrogate)
+        } else {
+            fail("$positionSurrogate type is incorrect")
+        }
+    }
+
+    "ToPositionSurrogate should map a Position2D to a Position2DSurrogate" {
+        val alchemist2DPosition = Euclidean2DPosition(2.5, 5.8)
+        val position2DSurrogate = toSuitablePositionSurrogate(alchemist2DPosition.dimensions)(alchemist2DPosition)
+        if (position2DSurrogate is Position2DSurrogate) {
+            checkToPositionSurrogate(alchemist2DPosition, position2DSurrogate)
+        } else {
+            fail("$position2DSurrogate type is incorrect")
+        }
+    }
+})
+fun <P : Position<out P>> checkToPositionSurrogate(position: P, positionSurrogate: PositionSurrogate) {
+    position.coordinates shouldBe positionSurrogate.coordinates
+    position.dimensions shouldBe positionSurrogate.dimensions
+    if (position is Position2D<*> && positionSurrogate is Position2DSurrogate) {
+        position.x shouldBe positionSurrogate.x
+        position.y shouldBe positionSurrogate.y
+    }
+}

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToStatusSurrogateTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/surrogates/utility/ToStatusSurrogateTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.surrogates.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+import it.unibo.alchemist.core.interfaces.Status
+
+class ToStatusSurrogateTest : StringSpec({
+    "ToStatusSurrogate should map a Status to a StatusSurrogate" {
+        Status.INIT.toStatusSurrogate() shouldBe StatusSurrogate.INIT
+        Status.READY.toStatusSurrogate() shouldBe StatusSurrogate.READY
+        Status.PAUSED.toStatusSurrogate() shouldBe StatusSurrogate.PAUSED
+        Status.RUNNING.toStatusSurrogate() shouldBe StatusSurrogate.RUNNING
+        Status.TERMINATED.toStatusSurrogate() shouldBe StatusSurrogate.TERMINATED
+    }
+})


### PR DESCRIPTION
This pull requests contains the mapping functions that converts the Alchemist JVM structures to the corresponding surrogate (multiplatform) classes.