### PR TITLE
feat(web-renderer): add Renderer interface and BitmapRenderer, add CommonState

### DIFF
--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 compileOnly(libs.spotbugs.annotations)
+                implementation(libs.korim)
                 implementation(libs.kotlin.stdlib)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.core)

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/renderer/Bitmap32Serializer.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/renderer/Bitmap32Serializer.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.renderer
+
+import com.soywiz.korim.bitmap.Bitmap32
+import com.soywiz.korim.color.RgbaArray
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.IntArraySerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+
+/**
+ * Serializer for [Bitmap32] class.
+ */
+object Bitmap32Serializer : KSerializer<Bitmap32> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Bitmap32") {
+        element<IntArray>("ints")
+        element<Int>("width")
+        element<Int>("height")
+    }
+
+    override fun serialize(encoder: Encoder, value: Bitmap32) =
+        encoder.encodeStructure(descriptor) {
+            encodeSerializableElement(descriptor, 0, IntArraySerializer(), value.ints)
+            encodeIntElement(descriptor, 1, value.width)
+            encodeIntElement(descriptor, 2, value.height)
+        }
+
+    override fun deserialize(decoder: Decoder): Bitmap32 =
+        decoder.decodeStructure(descriptor) {
+            var ints = intArrayOf()
+            var width = -1
+            var height = -1
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> ints = decodeSerializableElement(descriptor, 0, IntArraySerializer())
+                    1 -> width = decodeIntElement(descriptor, 1)
+                    2 -> height = decodeIntElement(descriptor, 2)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
+            Bitmap32(width, height, RgbaArray(ints))
+        }
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/renderer/BitmapRenderer.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/renderer/BitmapRenderer.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.renderer
+
+import com.soywiz.korim.bitmap.Bitmap
+import com.soywiz.korim.bitmap.Bitmap32
+import com.soywiz.korim.bitmap.context2d
+import com.soywiz.korim.color.Colors
+import com.soywiz.korim.vector.Context2d
+import com.soywiz.korma.geom.Point
+import com.soywiz.korma.geom.vector.circle
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.NodeSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+
+/**
+ * This implementation renders a [com.soywiz.korim.bitmap.Bitmap].
+ * The rendering works on 2D environments only as it uses a [com.soywiz.korim.vector.Context2d].
+ * @param <TS> the type of the concentration surrogate.
+ */
+class BitmapRenderer<in TS : Any, in PS : PositionSurrogate> : Renderer<TS, PS, Bitmap> {
+
+    companion object {
+        private const val defaultNodeRadius = 0.1
+        private const val defaultHeight = 1000
+        private const val defaultWidth = 1000
+        private const val defaultScaleFactor = 25
+    }
+
+    /**
+     * Renders the environment.
+     * @param environmentSurrogate the [it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate] to render.
+     * @return a [com.soywiz.korim.bitmap.Bitmap] representing the environment.
+     */
+    override fun render(environmentSurrogate: EnvironmentSurrogate<TS, PS>): Bitmap {
+        require(environmentSurrogate.dimensions == 2)
+        return Bitmap32(defaultWidth, defaultHeight, premultiplied = false).context2d {
+            cartesianPlane()
+            translate(width / 2.0, height / 2.0)
+            scale(defaultScaleFactor, defaultScaleFactor)
+            environmentSurrogate.nodes.forEach {
+                alchemistNode(it, defaultNodeRadius)
+            }
+        }
+    }
+
+    /**
+     * Draws the two cartesian axis on the [com.soywiz.korim.vector.Context2d].
+     */
+    private fun Context2d.cartesianPlane() {
+        fill(Colors.WHITE)
+        beginPath()
+        moveTo((width / 2).toDouble(), 0.0)
+        lineTo((width / 2).toDouble(), height.toDouble())
+        moveTo(0.0, (height / 2).toDouble())
+        lineTo(width.toDouble(), (height / 2).toDouble())
+        stroke()
+    }
+
+    /**
+     * Draws a [it.unibo.alchemist.common.model.surrogate.NodeSurrogate] on the [com.soywiz.korim.vector.Context2d].
+     * @param node the node surrogate to draw.
+     * @param radius the radius of the node.
+     */
+    private fun Context2d.alchemistNode(node: NodeSurrogate<TS, PS>, radius: Double) {
+        beginPath()
+        circle(node.position.toPoint(), radius)
+        stroke()
+    }
+
+    private fun PositionSurrogate.toPoint(): Point {
+        require(dimensions == 2)
+        return Point(coordinates[0], coordinates[1])
+    }
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/renderer/Renderer.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/renderer/Renderer.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.renderer
+
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+
+/**
+ * Renderer of an [EnvironmentSurrogate].
+ * @param <TS> the type of the concentration surrogate.
+ * @param <PS> the type of the position surrogate.
+ * @param <R> the type of the result, presumably a graphic representation, like a raster image or an SVG string.
+ */
+interface Renderer<in TS : Any, in PS : PositionSurrogate, out R> {
+
+    /**
+     * Renders the [EnvironmentSurrogate].
+     * @param environmentSurrogate the [EnvironmentSurrogate] to render.
+     * @return the result of the rendering.
+     */
+    fun render(environmentSurrogate: EnvironmentSurrogate<TS, PS>): R
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/state/CommonState.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/state/CommonState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.state
+
+import com.soywiz.korim.bitmap.Bitmap
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.common.renderer.BitmapRenderer
+import it.unibo.alchemist.common.renderer.Renderer
+
+/**
+ * The common state of the client and the server.
+ * This class includes common components that both systems need to have.
+ * @param renderer the [Renderer] that renders an [it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate].
+ */
+open class CommonState(
+    val renderer: Renderer<Any, PositionSurrogate, Bitmap> = BitmapRenderer()
+)

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/renderer/Bitmap32SerializerTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/renderer/Bitmap32SerializerTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.renderer
+
+import com.soywiz.korim.bitmap.Bitmap
+import com.soywiz.korim.bitmap.Bitmap32
+import com.soywiz.korim.paint.ColorPaint
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+
+class Bitmap32SerializerTest : StringSpec({
+    "Bitmap32 should be serialized and deserialized correctly" {
+        val bmp: Bitmap = Bitmap32(1000, 1000, ColorPaint(0))
+        val serialized = jsonFormat.encodeToString(Bitmap32Serializer, bmp.toBMP32IfRequired())
+        val deserialized = jsonFormat.decodeFromString(Bitmap32Serializer, serialized)
+        deserialized shouldBe bmp
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/renderer/BitmapRendererTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/renderer/BitmapRendererTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.renderer
+
+import com.soywiz.korim.bitmap.Bitmap
+import com.soywiz.korim.bitmap.Bitmap32
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import it.unibo.alchemist.common.model.surrogate.EmptyConcentrationSurrogate
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.MoleculeSurrogate
+import it.unibo.alchemist.common.model.surrogate.NodeSurrogate
+import it.unibo.alchemist.common.model.surrogate.Position2DSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+
+class BitmapRendererTest : StringSpec({
+
+    val envSurrogate: EnvironmentSurrogate<Any, PositionSurrogate> = EnvironmentSurrogate(
+        2,
+        listOf(
+            NodeSurrogate(
+                0,
+                mapOf(MoleculeSurrogate("concentration") to EmptyConcentrationSurrogate),
+                Position2DSurrogate(5.6, 8.42)
+            )
+        )
+    )
+
+    val renderer: Renderer<Any, PositionSurrogate, Bitmap> = BitmapRenderer()
+
+    "BitmapRenderer should output a Bitmap correctly" {
+        val bmp = renderer.render(envSurrogate)
+        (bmp is Bitmap32) shouldBe true
+        val ser = jsonFormat.encodeToString(Bitmap32Serializer, bmp.toBMP32IfRequired())
+        val des = jsonFormat.decodeFromString(Bitmap32Serializer, ser)
+        bmp.height shouldBe des.height
+        bmp.width shouldBe des.width
+        bmp.toBMP32().ints shouldBe des.ints
+        bmp shouldBe des
+    }
+
+    "BitmapRenderer can't work with Environments with != 2 dimensions" {
+        val mockEnv: EnvironmentSurrogate<Any, PositionSurrogate> = EnvironmentSurrogate(-1, listOf())
+        shouldThrow<IllegalArgumentException> {
+            renderer.render(mockEnv)
+        }
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/state/CommonStateTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/state/CommonStateTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.state
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldNotBe
+
+class CommonStateTest : StringSpec({
+    "CommonState should be initialized with a default renderer" {
+        val state = CommonState()
+        state.renderer shouldNotBe null
+    }
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ jpx = "io.jenetics:jpx:2.3.0"
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 konf = { module = "com.uchuhimo:konf", version.ref = "konf" }
+korim = "com.soywiz.korlibs.korim:korim:3.4.0"
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }


### PR DESCRIPTION
This PR contains the Renderer interface and the BitmapRenderer implementation. The CommonState class, which contains a renderer (that both the server and the client should have), is also included. CommonState is a class used by other specialized class that will be added in jvmMain and jsMain.