### PR TITLE
feat(web-renderer): add EnvironmentMonitor and ServerState

### DIFF
--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitor.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitor.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.monitor
+
+import it.unibo.alchemist.boundary.interfaces.OutputMonitor
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.model.interfaces.Actionable
+import it.unibo.alchemist.model.interfaces.Environment
+import it.unibo.alchemist.model.interfaces.Position
+import it.unibo.alchemist.model.interfaces.Time
+import it.unibo.alchemist.server.state.ServerStore.store
+import it.unibo.alchemist.server.state.actions.SetEnvironmentSurrogate
+import it.unibo.alchemist.server.surrogates.utility.toEnvironmentSurrogate
+
+/**
+ * A monitor that maps an [Environment] into an [EnvironmentSurrogate] and saves it in the [store].
+ *
+ *  @param <P> position type.
+ *  @param <T> concentration type.
+ *  @param <PS> position surrogate type.
+ *  @param <TS> concentration surrogate type.
+ *  @param toConcentrationSurrogate the mapping function from <T> to <TS>.
+ *  @param toPositionSurrogate the mapping function from <P> to <PS>.
+ */
+class EnvironmentMonitor<T, P, TS, PS> (
+    private val toConcentrationSurrogate: (T) -> TS,
+    private val toPositionSurrogate: (P) -> PS
+) : OutputMonitor<T, P>
+where TS : Any, P : Position<P>, PS : PositionSurrogate {
+
+    /**
+     * Every time the [Environment] changes, map it to [EnvironmentSurrogate] class and save it in the [store].
+     * @param environment the updated environment.
+     * @param reaction the reaction that triggered the update.
+     * @param time the current time.
+     * @param step the current step.
+     */
+    override fun stepDone(environment: Environment<T, P>, reaction: Actionable<T>?, time: Time, step: Long) {
+        val newEnvironmentSurrogate: EnvironmentSurrogate<Any, PositionSurrogate> =
+            environment.toEnvironmentSurrogate(toConcentrationSurrogate, toPositionSurrogate)
+        store.dispatch(SetEnvironmentSurrogate(newEnvironmentSurrogate))
+    }
+
+    /**
+     * Call the stepDone(Environment<T, P>, Actionable<T>?, Time, Long) method setting time and step to 0.
+     * @param environment the environment.
+     */
+    override fun initialized(environment: Environment<T, P>) {
+        this.stepDone(environment, null, Time.ZERO, 0L)
+    }
+
+    /**
+     * Call the stepDone(Environment<T, P>, Actionable<T>?, Time, Long) method setting the reaction to null.
+     * @param environment the updated environment.
+     * @param time the final time.
+     * @param step the final step.
+     */
+    override fun finished(environment: Environment<T, P>, time: Time, step: Long) {
+        this.stepDone(environment, null, time, step)
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactory.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactory.kt
@@ -10,9 +10,7 @@
 package it.unibo.alchemist.server.monitor
 
 import it.unibo.alchemist.boundary.interfaces.OutputMonitor
-import it.unibo.alchemist.model.SAPEREIncarnation
 import it.unibo.alchemist.model.interfaces.Environment
-import it.unibo.alchemist.model.interfaces.Incarnation
 import it.unibo.alchemist.server.surrogates.utility.ToConcentrationSurrogate.toEmptyConcentration
 import it.unibo.alchemist.server.surrogates.utility.ToPositionSurrogate.toSuitablePositionSurrogate
 
@@ -22,27 +20,15 @@ import it.unibo.alchemist.server.surrogates.utility.ToPositionSurrogate.toSuitab
 object EnvironmentMonitorFactory {
 
     /**
-     * Create an EnvironmentMonitor suitable for the given simulation.
+     * Create an EnvironmentMonitor suitable for the given simulation, using a toConcentration function based on the
+     * [it.unibo.alchemist.model.interfaces.Incarnation] and mapping the [it.unibo.alchemist.model.interfaces.Position]
+     * to the correct [it.unibo.alchemist.common.model.surrogate.PositionSurrogate] using the environment dimensions.
      * @param environment the environment of the simulation.
      * @return the [OutputMonitor].
      */
     fun makeEnvironmentMonitor(environment: Environment<*, *>): OutputMonitor<Any, Nothing> =
-        makeEnvironmentMonitor(environment.incarnation, environment.dimensions)
-
-    /**
-     * Create an EnvironmentMonitor suitable for the given simulation, mapping the concentration based on the
-     * [it.unibo.alchemist.model.interfaces.Incarnation] and mapping the [it.unibo.alchemist.model.interfaces.Position]
-     * to the correct [it.unibo.alchemist.common.model.surrogate.PositionSurrogate] using the environment dimensions.
-     * @param incarnation the [it.unibo.alchemist.model.interfaces.Incarnation] of the simulation.
-     * @param dimensions the number of dimensions of the simulation.
-     * @return the [OutputMonitor].
-     */
-    fun makeEnvironmentMonitor(incarnation: Incarnation<*, *>, dimensions: Int = 2): OutputMonitor<Any, Nothing> =
         EnvironmentMonitor(
-            when (incarnation) {
-                is SAPEREIncarnation<*> -> toEmptyConcentration // TODO change to correct implementation
-                else -> toEmptyConcentration
-            },
-            toSuitablePositionSurrogate(dimensions)
+            toEmptyConcentration, // TODO change to correct implementation depending on the incarnation
+            toSuitablePositionSurrogate(environment.dimensions)
         )
 }

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactory.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactory.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.monitor
+
+import it.unibo.alchemist.boundary.interfaces.OutputMonitor
+import it.unibo.alchemist.model.SAPEREIncarnation
+import it.unibo.alchemist.model.interfaces.Environment
+import it.unibo.alchemist.model.interfaces.Incarnation
+import it.unibo.alchemist.server.surrogates.utility.ToConcentrationSurrogate.toEmptyConcentration
+import it.unibo.alchemist.server.surrogates.utility.ToPositionSurrogate.toSuitablePositionSurrogate
+
+/**
+ * A factory for [EnvironmentMonitor]s. Monitors are returned as [OutputMonitor].
+ */
+object EnvironmentMonitorFactory {
+
+    /**
+     * Create an EnvironmentMonitor suitable for the given simulation.
+     * @param environment the environment of the simulation.
+     * @return the [OutputMonitor].
+     */
+    fun makeEnvironmentMonitor(environment: Environment<*, *>): OutputMonitor<Any, Nothing> =
+        makeEnvironmentMonitor(environment.incarnation, environment.dimensions)
+
+    /**
+     * Create an EnvironmentMonitor suitable for the given simulation, mapping the concentration based on the
+     * [it.unibo.alchemist.model.interfaces.Incarnation] and mapping the [it.unibo.alchemist.model.interfaces.Position]
+     * to the correct [it.unibo.alchemist.common.model.surrogate.PositionSurrogate] using the environment dimensions.
+     * @param incarnation the [it.unibo.alchemist.model.interfaces.Incarnation] of the simulation.
+     * @param dimensions the number of dimensions of the simulation.
+     * @return the [OutputMonitor].
+     */
+    fun makeEnvironmentMonitor(incarnation: Incarnation<*, *>, dimensions: Int = 2): OutputMonitor<Any, Nothing> =
+        EnvironmentMonitor(
+            when (incarnation) {
+                is SAPEREIncarnation<*> -> toEmptyConcentration // TODO change to correct implementation
+                else -> toEmptyConcentration
+            },
+            toSuitablePositionSurrogate(dimensions)
+        )
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerState.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerState.kt
@@ -18,8 +18,14 @@ import it.unibo.alchemist.server.state.reducers.simulationReducer
 
 /**
  * The state of the server.
+ * The [ServerState] is managed using the
+ * <a href="https://reduxkotlin.org/introduction/core-concepts">Core concepts of the ReduxKotlin library</a>.
+ * Like in the original Redux library the state is stored in a single class that contains other objects via composition.
+ * The state can be changed using actions that must be defined in advance.
+ * The unique store that encapsulate the [ServerState] is {@link it.unibo.alchemist.server.state.ServerStore}.
  * @param simulation the simulation. Defaults to null.
  * @param environmentSurrogate the current environment surrogate. Defaults to an uninitializedEnvironment.
+ * @see <a href="https://reduxkotlin.org/">ReduxKotlin Documentation</a>
  */
 data class ServerState(
     val simulation: Simulation<Any, Nothing>? = null,

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerState.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerState.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.state
+
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.common.state.CommonState
+import it.unibo.alchemist.core.interfaces.Simulation
+import it.unibo.alchemist.server.state.reducers.environmentSurrogateReducer
+import it.unibo.alchemist.server.state.reducers.simulationReducer
+
+/**
+ * The state of the server.
+ * @param simulation the simulation. Defaults to null.
+ * @param environmentSurrogate the current environment surrogate. Defaults to an uninitializedEnvironment.
+ */
+data class ServerState(
+    val simulation: Simulation<Any, Nothing>? = null,
+    val environmentSurrogate: EnvironmentSurrogate<Any, PositionSurrogate> =
+        EnvironmentSurrogate.uninitializedEnvironment()
+) : CommonState()
+
+/**
+ * Root reducer of the server. Uses all the other server reducers.
+ * @param state the old server state.
+ * @param action the action to be applied.
+ */
+fun rootReducer(
+    state: ServerState,
+    action: Any
+): ServerState = ServerState(
+    simulation = simulationReducer(state.simulation, action),
+    environmentSurrogate = environmentSurrogateReducer(state.environmentSurrogate, action)
+)

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerStore.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerStore.kt
@@ -13,7 +13,10 @@ import org.reduxkotlin.Store
 import org.reduxkotlin.createThreadSafeStore
 
 /**
- * The store of the server. Can be accesed anywhere thanks to the singleton pattern.
+ * The store of the server.
+ * This class uses the core concepts of the original Redux library.
+ * Thanks to the singleton pattern, the [ServerState] can be accessed or edited from anywhere.
+ * @see <a href="https://reduxkotlin.org/">ReduxKotlin Documentation</a>
  */
 object ServerStore {
     /**

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerStore.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/ServerStore.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.state
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.createThreadSafeStore
+
+/**
+ * The store of the server. Can be accesed anywhere thanks to the singleton pattern.
+ */
+object ServerStore {
+    /**
+     * The redux store of the server.
+     */
+    val store: Store<ServerState> = createThreadSafeStore(::rootReducer, ServerState())
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/actions/SetEnvironmentSurrogate.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/actions/SetEnvironmentSurrogate.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.state.actions
+
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+
+/**
+ * Redux action to set the [EnvironmentSurrogate] of the application.
+ * @param <TS> the type of the concentration surrogate.
+ * @param <PS> the type of the [PositionSurrogate].
+ * @param environmentSurrogate the new environment surrogate.
+ */
+data class SetEnvironmentSurrogate<out TS : Any, out PS : PositionSurrogate>(
+    val environmentSurrogate: EnvironmentSurrogate<TS, PS>
+)

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/actions/SetSimulation.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/actions/SetSimulation.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.state.actions
+
+import it.unibo.alchemist.core.interfaces.Simulation
+
+/**
+ * Redux action to set the [it.unibo.alchemist.core.interfaces.Simulation] of the application.
+ * @param simulation the new [it.unibo.alchemist.core.interfaces.Simulation].
+ */
+data class SetSimulation(val simulation: Simulation<Any, Nothing>?)

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/reducers/EnvironmentSurrogateReducer.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/reducers/EnvironmentSurrogateReducer.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.state.reducers
+
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.server.state.actions.SetEnvironmentSurrogate
+
+/**
+ * Reducer for the environment surrogate.
+ * @param state the current state.
+ * @param action the requested action.
+ */
+fun environmentSurrogateReducer(
+    state: EnvironmentSurrogate<Any, PositionSurrogate>,
+    action: Any
+): EnvironmentSurrogate<Any, PositionSurrogate> =
+    when (action) {
+        is SetEnvironmentSurrogate<*, *> -> action.environmentSurrogate
+        else -> state
+    }

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/reducers/SimulationReducer.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/state/reducers/SimulationReducer.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.state.reducers
+
+import it.unibo.alchemist.core.interfaces.Simulation
+import it.unibo.alchemist.server.state.actions.SetSimulation
+
+/**
+ * Reducer for the [it.unibo.alchemist.core.interfaces.Simulation].
+ * @param state the current [it.unibo.alchemist.core.interfaces.Simulation].
+ * @param action the requested action.
+ * @return the new [it.unibo.alchemist.core.interfaces.Simulation].
+ */
+fun simulationReducer(state: Simulation<Any, Nothing>?, action: Any): Simulation<Any, Nothing>? =
+    when (action) {
+        is SetSimulation -> action.simulation
+        else -> state
+    }

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactoryTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactoryTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.monitor
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.TestUtility.webRendererTestEnvironments
+import it.unibo.alchemist.server.monitor.EnvironmentMonitorFactory.makeEnvironmentMonitor
+
+class EnvironmentMonitorFactoryTest : StringSpec({
+    "EnvironmentMonitorFactory should create a monitor using different strategy" {
+        webRendererTestEnvironments<Any, Nothing>().forEach {
+            listOf(
+                makeEnvironmentMonitor(it.incarnation),
+                makeEnvironmentMonitor(it),
+                makeEnvironmentMonitor(it.incarnation, it.dimensions)
+            ).forEach { monitor ->
+                monitor::class shouldBe EnvironmentMonitor::class
+            }
+        }
+    }
+})

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactoryTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorFactoryTest.kt
@@ -17,11 +17,7 @@ import it.unibo.alchemist.server.monitor.EnvironmentMonitorFactory.makeEnvironme
 class EnvironmentMonitorFactoryTest : StringSpec({
     "EnvironmentMonitorFactory should create a monitor using different strategy" {
         webRendererTestEnvironments<Any, Nothing>().forEach {
-            listOf(
-                makeEnvironmentMonitor(it.incarnation),
-                makeEnvironmentMonitor(it),
-                makeEnvironmentMonitor(it.incarnation, it.dimensions)
-            ).forEach { monitor ->
+            makeEnvironmentMonitor(it).let { monitor ->
                 monitor::class shouldBe EnvironmentMonitor::class
             }
         }

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/monitor/EnvironmentMonitorTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.monitor
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldNotBe
+import it.unibo.alchemist.TestUtility.webRendererTestEnvironments
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.model.interfaces.Time
+import it.unibo.alchemist.server.monitor.EnvironmentMonitorFactory.makeEnvironmentMonitor
+import it.unibo.alchemist.server.state.ServerStore
+import it.unibo.alchemist.server.state.actions.SetEnvironmentSurrogate
+
+class EnvironmentMonitorTest : StringSpec({
+    fun checkStep(action: () -> Unit) {
+        val initialEnvironment = ServerStore.store.state.environmentSurrogate
+        action()
+        initialEnvironment shouldNotBe ServerStore.store.state.environmentSurrogate
+        ServerStore.store.dispatch(SetEnvironmentSurrogate(EnvironmentSurrogate.uninitializedEnvironment()))
+    }
+
+    "EnvironmentMonitor stepDone should work as expected" {
+        webRendererTestEnvironments<Any, Nothing>().forEach {
+            val environmentMonitor = makeEnvironmentMonitor(it)
+            checkStep {
+                environmentMonitor.stepDone(it, null, Time.ZERO, 111)
+            }
+            checkStep {
+                environmentMonitor.initialized(it)
+            }
+            checkStep {
+                environmentMonitor.finished(it, Time.ZERO, 222)
+            }
+        }
+    }
+})

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/state/ServerStoreTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/state/ServerStoreTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.state
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.TestUtility.webRendererTestEnvironments
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate.Companion.uninitializedEnvironment
+import it.unibo.alchemist.server.state.actions.SetEnvironmentSurrogate
+import it.unibo.alchemist.server.state.actions.SetSimulation
+import it.unibo.alchemist.server.surrogates.utility.ToConcentrationSurrogate.toEmptyConcentration
+import it.unibo.alchemist.server.surrogates.utility.toEnvironmentSurrogate
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.createThreadSafeStore
+
+class ServerStoreTest : StringSpec({
+
+    val serverStore: Store<ServerState> = createThreadSafeStore(::rootReducer, ServerState())
+
+    "ServerStore should be empty at the beginning" {
+        serverStore.state.simulation shouldBe null
+        serverStore.state.environmentSurrogate shouldBe uninitializedEnvironment()
+    }
+
+    "ServerState can be updated with a SetSimulation action" {
+        webRendererTestEnvironments<Any, Nothing>().forEach {
+            serverStore.dispatch(SetSimulation(it.simulation))
+            serverStore.state.simulation shouldBe it.simulation
+        }
+    }
+
+    "ServerStore can be updated with a SetEnvironmentSurrogate action" {
+        webRendererTestEnvironments<Any, Nothing>().forEach {
+            val envSurrogate = it.toEnvironmentSurrogate(toEmptyConcentration)
+            serverStore.dispatch(SetEnvironmentSurrogate(envSurrogate))
+            serverStore.state.environmentSurrogate shouldBe envSurrogate
+        }
+    }
+})


### PR DESCRIPTION
This PR contains the EnvironmentMonitor implementation. The monitor maps the Environment to its surrogate class and stores it in the Server state, which is also added in this PR.