### PR TITLE
feat(web-renderer): add Server Routes logic

### DIFF
--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/RenderMode.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/model/RenderMode.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model
+
+/**
+ * Enum to represent the Render mode of the application.
+ */
+enum class RenderMode {
+    /**
+     * The rendering computation is executed on the client.
+     */
+    CLIENT,
+
+    /**
+     * A strategy will choose the best rendering mode.
+     */
+    AUTO,
+
+    /**
+     * The rendering computation is executed on the server.
+     */
+    SERVER
+}

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Routes.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Routes.kt
@@ -13,7 +13,7 @@ package it.unibo.alchemist.common.utility
  * Objects that store all the route path. Since this object is part of the common sourceSet, both Client and Serve can
  * refer to the correct Route maintaining consistency and reducing the number of possible errors and bug.
  */
-object Ruotes {
+object Routes {
     /**
      * Base environment path, for all Environment related operations.
      */

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Routes.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Routes.kt
@@ -16,6 +16,7 @@ package it.unibo.alchemist.common.utility
 object Routes {
     /**
      * Base environment path, for all Environment related operations.
+     * Those are operations that acts directly on the original Enviornment interface.
      */
     private const val environmentPath: String = "/environment"
 
@@ -33,6 +34,7 @@ object Routes {
 
     /**
      * Base simulation path, for simulation related operations.
+     * Those are operations that acts directly on the original Simulation interface.
      */
     private const val simulationPath: String = "/simulation"
 

--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Ruotes.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Ruotes.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.utility
+
+/**
+ * Objects that store all the route path. Since this object is part of the common sourceSet, both Client and Serve can
+ * refer to the correct Route maintaining consistency and reducing the number of possible errors and bug.
+ */
+object Ruotes {
+    /**
+     * Base environment path, for all Environment related operations.
+     */
+    private const val environmentPath: String = "/environment"
+
+    /**
+     * Route to get an Environment in a serialized form that needs to be rendered by the client, as
+     * [it.unibo.alchemist.common.model.RenderMode.CLIENT] was requested.
+     */
+    const val environmentClientPath: String = "$environmentPath/client"
+
+    /**
+     * Route to get an Environment already renderer by the Server, as
+     * [it.unibo.alchemist.common.model.RenderMode.SERVER] was requested.
+     */
+    const val environmentServerPath: String = "$environmentPath/server"
+
+    /**
+     * Base simulation path, for simulation related operations.
+     */
+    private const val simulationPath: String = "/simulation"
+
+    /**
+     * Route to get the [it.unibo.alchemist.common.model.surrogate.StatusSurrogate] of the simulation.
+     */
+    const val simulationStatusPath: String = "$simulationPath/status"
+
+    /**
+     * Route to start the simulation.
+     */
+    const val simulationPlayPath: String = "$simulationPath/play"
+
+    /**
+     * Route to pause the simulation.
+     */
+    const val simulationPausePath: String = "$simulationPath/pause"
+}

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/RenderModeTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/model/RenderModeTest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.model
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class RenderModeTest : StringSpec({
+    "RenderMode are just CLIENT, SERVER and AUTO" {
+        val renderModes = RenderMode.values()
+        renderModes.size shouldBe 3
+        renderModes.map { it }.containsAll(listOf(RenderMode.CLIENT, RenderMode.SERVER, RenderMode.AUTO)) shouldBe true
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/utility/RoutesTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/utility/RoutesTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.utility.Ruotes.environmentClientPath
+import it.unibo.alchemist.common.utility.Ruotes.environmentServerPath
+import it.unibo.alchemist.common.utility.Ruotes.simulationPausePath
+import it.unibo.alchemist.common.utility.Ruotes.simulationPlayPath
+import it.unibo.alchemist.common.utility.Ruotes.simulationStatusPath
+
+class RoutesTest : StringSpec({
+    "All the routes strings should be correct" {
+        environmentClientPath shouldBe "/environment/client"
+        environmentServerPath shouldBe "/environment/server"
+        simulationStatusPath shouldBe "/simulation/status"
+        simulationPlayPath shouldBe "/simulation/play"
+        simulationPausePath shouldBe "/simulation/pause"
+    }
+})

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/utility/RoutesTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/utility/RoutesTest.kt
@@ -11,11 +11,11 @@ package it.unibo.alchemist.common.utility
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import it.unibo.alchemist.common.utility.Ruotes.environmentClientPath
-import it.unibo.alchemist.common.utility.Ruotes.environmentServerPath
-import it.unibo.alchemist.common.utility.Ruotes.simulationPausePath
-import it.unibo.alchemist.common.utility.Ruotes.simulationPlayPath
-import it.unibo.alchemist.common.utility.Ruotes.simulationStatusPath
+import it.unibo.alchemist.common.utility.Routes.environmentClientPath
+import it.unibo.alchemist.common.utility.Routes.environmentServerPath
+import it.unibo.alchemist.common.utility.Routes.simulationPausePath
+import it.unibo.alchemist.common.utility.Routes.simulationPlayPath
+import it.unibo.alchemist.common.utility.Routes.simulationStatusPath
 
 class RoutesTest : StringSpec({
     "All the routes strings should be correct" {

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/InstallModule.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/InstallModule.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.modules
+
+import io.ktor.http.HttpMethod
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.compression.Compression
+import io.ktor.server.plugins.compression.gzip
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.cors.routing.CORS
+
+/**
+ * Ktor module that adds all the [install] configuration to the application.
+ * The [io.ktor.serialization.kotlinx.json.JsonSupportKt.json] format is used for content negotiation.
+ * A cors configuration is included.
+ * Finally, an encoder for [Compression] is included.
+ * @see <a href="https://ktor.io/docs/modules.html">Ktor Modules</a>
+ */
+fun Application.installModule() {
+    install(ContentNegotiation) {
+        json()
+    }
+    install(CORS) {
+        allowMethod(HttpMethod.Get)
+        allowMethod(HttpMethod.Post)
+        anyHost()
+    }
+    install(Compression) {
+        gzip()
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/RoutingModule.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/RoutingModule.kt
@@ -25,15 +25,10 @@ import it.unibo.alchemist.server.routes.mainRoute
 fun Application.routingModule() {
     routing {
         mainRoute()
-
         simulationStatus()
-
         simulationActionPlay()
-
         simulationActionPause()
-
         environmentServerMode()
-
         environmentClientMode()
     }
 }

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/RoutingModule.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/RoutingModule.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.modules
+
+import io.ktor.server.application.Application
+import io.ktor.server.routing.routing
+import it.unibo.alchemist.server.routes.EnvironmentRoute.environmentClientMode
+import it.unibo.alchemist.server.routes.EnvironmentRoute.environmentServerMode
+import it.unibo.alchemist.server.routes.SimulationRoute.simulationActionPause
+import it.unibo.alchemist.server.routes.SimulationRoute.simulationActionPlay
+import it.unibo.alchemist.server.routes.SimulationRoute.simulationStatus
+import it.unibo.alchemist.server.routes.mainRoute
+
+/**
+ * Ktor module that adds all the routing configuration to an application.
+ * @see <a href="https://ktor.io/docs/modules.html">Ktor Modules</a>
+ */
+fun Application.routingModule() {
+    routing {
+        mainRoute()
+
+        simulationStatus()
+
+        simulationActionPlay()
+
+        simulationActionPause()
+
+        environmentServerMode()
+
+        environmentClientMode()
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/EnvironmentRoute.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/EnvironmentRoute.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.routes
+
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import it.unibo.alchemist.common.model.serialization.encodeEnvironmentSurrogate
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import it.unibo.alchemist.common.renderer.Bitmap32Serializer
+import it.unibo.alchemist.common.utility.Ruotes.environmentClientPath
+import it.unibo.alchemist.common.utility.Ruotes.environmentServerPath
+import it.unibo.alchemist.server.state.ServerStore.store
+import it.unibo.alchemist.server.utility.Response
+import it.unibo.alchemist.server.utility.Response.Companion.respond
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Logic of the Routes in the /environment path.
+ */
+object EnvironmentRoute {
+
+    /**
+     * Route of type GET that retrieve current Environment.
+     * The server will render the environment and send it to the client in an already rendered form.
+     * The HTTP [Response] sent to the client can be of type:
+     * 200 (OK) the Environment is sent to the client.
+     */
+    fun Route.environmentServerMode() {
+        get(environmentServerPath) {
+            respond(Response(content = renderedEnvironment()))
+        }
+    }
+
+    /**
+     * Route of type GET that retrieve current Environment.
+     * The server will send the environment to the client in a serialized form.
+     * The HTTP [Response] sent to the client can be of type:
+     * 200 (OK) the Environment is sent to the client.
+     */
+    fun Route.environmentClientMode() {
+        get(environmentClientPath) {
+            respond(Response(content = jsonFormat.encodeEnvironmentSurrogate(store.state.environmentSurrogate)))
+        }
+    }
+
+    private suspend fun renderedEnvironment(
+        dispatcher: CoroutineDispatcher = Dispatchers.Default
+    ): String {
+        return withContext(dispatcher) {
+            jsonFormat.encodeToString(
+                Bitmap32Serializer,
+                store.state.renderer.render(
+                    store.state.environmentSurrogate
+                ).toBMP32IfRequired()
+            )
+        }
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/EnvironmentRoute.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/EnvironmentRoute.kt
@@ -14,8 +14,8 @@ import io.ktor.server.routing.get
 import it.unibo.alchemist.common.model.serialization.encodeEnvironmentSurrogate
 import it.unibo.alchemist.common.model.serialization.jsonFormat
 import it.unibo.alchemist.common.renderer.Bitmap32Serializer
-import it.unibo.alchemist.common.utility.Ruotes.environmentClientPath
-import it.unibo.alchemist.common.utility.Ruotes.environmentServerPath
+import it.unibo.alchemist.common.utility.Routes.environmentClientPath
+import it.unibo.alchemist.common.utility.Routes.environmentServerPath
 import it.unibo.alchemist.server.state.ServerStore.store
 import it.unibo.alchemist.server.utility.Response
 import it.unibo.alchemist.server.utility.Response.Companion.respond

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/MainRoute.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/MainRoute.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.routes
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode.Companion.NotFound
+import io.ktor.server.application.call
+import io.ktor.server.http.content.resources
+import io.ktor.server.http.content.static
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import it.unibo.alchemist.server.utility.Response
+import it.unibo.alchemist.server.utility.Response.Companion.respond
+
+/**
+ * Route of type GET that sends the index page to the client.
+ * The HTTP [Response] sent to the client can be of type:
+ * 200 (OK) the index.html resource is correctly sent to the client.
+ * 404 (Not Found) the index.html resource was not found.
+ */
+fun Route.mainRoute() {
+    get("/") {
+        this::class.java.classLoader.getResource("index.html")?.let { resource ->
+            call.respondText(resource.readText(), ContentType.Text.Html)
+        } ?: respond(Response(NotFound, "Main index.html is missing."))
+    }
+
+    static("/") {
+        resources("")
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
@@ -58,10 +58,9 @@ object SimulationRoute {
      */
     fun Route.simulationActionPlay() {
         post(simulationPlayPath) {
-            respondAction(
-                { simulation -> simulation.play() },
-                additionalCheck = Pair(Status.RUNNING, "The Simulation is already running.")
-            )
+            respondAction(Pair(Status.RUNNING, "The Simulation is already running.")) { simulation ->
+                simulation.play()
+            }
         }
     }
 
@@ -74,22 +73,21 @@ object SimulationRoute {
      */
     fun Route.simulationActionPause() {
         post(simulationPausePath) {
-            respondAction(
-                { simulation -> simulation.pause() },
-                additionalCheck = Pair(Status.PAUSED, "The Simulation is already paused.")
-            )
+            respondAction(Pair(Status.PAUSED, "The Simulation is already paused.")) { simulation ->
+                simulation.pause()
+            }
         }
     }
 
     /**
      * Private function that checks the simulation Status, executes the requested action if possible and responds.
-     * @param action the action to execute on the simulation.
      * @param additionalCheck a [Pair] representing an additional Status check, first is an invalid [Status] and second
      * is the error message.
+     * @param action the action to execute on the simulation.
      */
     private suspend fun PipelineContext<Unit, ApplicationCall>.respondAction(
-        action: (Simulation<Any, Nothing>) -> Unit,
-        additionalCheck: Pair<Status, String>
+        additionalCheck: Pair<Status, String>,
+        action: (Simulation<Any, Nothing>) -> Unit
     ) {
         store.state.simulation?.let { simulation ->
             respond(

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
@@ -17,9 +17,9 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.util.pipeline.PipelineContext
-import it.unibo.alchemist.common.utility.Ruotes.simulationPausePath
-import it.unibo.alchemist.common.utility.Ruotes.simulationPlayPath
-import it.unibo.alchemist.common.utility.Ruotes.simulationStatusPath
+import it.unibo.alchemist.common.utility.Routes.simulationPausePath
+import it.unibo.alchemist.common.utility.Routes.simulationPlayPath
+import it.unibo.alchemist.common.utility.Routes.simulationStatusPath
 import it.unibo.alchemist.core.interfaces.Simulation
 import it.unibo.alchemist.core.interfaces.Status
 import it.unibo.alchemist.server.utility.Response.Companion.respond

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.routes
+
+import io.ktor.http.HttpStatusCode.Companion.Conflict
+import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.HttpStatusCode.Companion.InternalServerError
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.util.pipeline.PipelineContext
+import it.unibo.alchemist.common.utility.Ruotes.simulationPausePath
+import it.unibo.alchemist.common.utility.Ruotes.simulationPlayPath
+import it.unibo.alchemist.common.utility.Ruotes.simulationStatusPath
+import it.unibo.alchemist.core.interfaces.Simulation
+import it.unibo.alchemist.core.interfaces.Status
+import it.unibo.alchemist.server.utility.Response.Companion.respond
+import it.unibo.alchemist.server.state.ServerStore.store
+import it.unibo.alchemist.server.surrogates.utility.toStatusSurrogate
+import it.unibo.alchemist.server.utility.Response
+
+/**
+ * Logic of the Routes in the /simulation path.
+ */
+object SimulationRoute {
+
+    /**
+     * Route that retrieve the simulation status and return it to the client mapping it with the [toStatusSurrogate]
+     * function.
+     * The HTTP [Response] sent to the client can be of type:
+     * 200 (OK) if the status is correctly retrieved;
+     * 500 (Server Error) if the Simulation was not loaded correctly.
+     */
+    fun Route.simulationStatus() {
+        get(simulationStatusPath) {
+            respond(
+                store.state.simulation?.status?.let { status ->
+                    Response(OK, status.toStatusSurrogate())
+                } ?: Response(InternalServerError, "Simulation not loaded.")
+            )
+        }
+    }
+
+    /**
+     * Route that plays the simulation by calling the [it.unibo.alchemist.core.interfaces.Simulation.play] method.
+     * The HTTP [Response] sent to the client can be of type:
+     * 200 (OK) if the operation succeed;
+     * 409 (Conflict) if the simulation is already running, or is in an invalid state to call the play operation;
+     * 500 (Server Error) if the Simulation was not loaded correctly.
+     */
+    fun Route.simulationActionPlay() {
+        post(simulationPlayPath) {
+            respondAction(
+                { simulation -> simulation.play() },
+                additionalCheck = Pair(Status.RUNNING, "The Simulation is already running.")
+            )
+        }
+    }
+
+    /**
+     * Route that pauses the simulation by calling the [it.unibo.alchemist.core.interfaces.Simulation.pause] method.
+     * The HTTP [Response] sent to the client can be of type:
+     * 200 (OK) if the operation succeed;
+     * 409 (Conflict) if the simulation is already paused, or is in an invalid state to call the pause operation;
+     * 500 (Server Error) if the Simulation was not loaded correctly.
+     */
+    fun Route.simulationActionPause() {
+        post(simulationPausePath) {
+            respondAction(
+                { simulation -> simulation.pause() },
+                additionalCheck = Pair(Status.PAUSED, "The Simulation is already paused.")
+            )
+        }
+    }
+
+    /**
+     * Private function that checks the simulation Status, executes the requested action if possible and responds.
+     * @param action the action to execute on the simulation.
+     * @param additionalCheck a [Pair] representing an additional Status check, first is an invalid [Status] and second
+     * is the error message.
+     */
+    private suspend fun PipelineContext<Unit, ApplicationCall>.respondAction(
+        action: (Simulation<Any, Nothing>) -> Unit,
+        additionalCheck: Pair<Status, String>
+    ) {
+        store.state.simulation?.let { simulation ->
+            respond(
+                when (simulation.status) {
+                    Status.INIT -> Response(Conflict, "The Simulation is being initialized.")
+                    Status.TERMINATED -> Response(Conflict, "The Simulation is terminated.")
+                    additionalCheck.first -> Response(Conflict, additionalCheck.second)
+                    else -> {
+                        action(simulation)
+                        Response(OK, "Action executed.")
+                    }
+                }
+            )
+        } ?: respond(Response(InternalServerError, "No Simulation found on the server."))
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/utility/Response.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/utility/Response.kt
@@ -27,7 +27,7 @@ data class Response<C>(
 ) {
     companion object {
         /**
-         * Utility function to dry the response process.
+         * Utility function to dry-run the response process.
          */
         suspend inline fun <reified C : Any> PipelineContext<Unit, ApplicationCall>.respond(response: Response<C>) {
             call.respond(response.code, response.content)

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/utility/Response.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/utility/Response.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.utility
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.util.pipeline.PipelineContext
+import io.ktor.http.HttpStatusCode.Companion.OK
+
+/**
+ * Class representing an HTTP response.
+ * @param code the [HttpStatusCode].
+ * @param content the content of the message.
+ */
+data class Response<C>(
+    val code: HttpStatusCode = OK,
+    val content: C
+) {
+    companion object {
+        /**
+         * Utility function to dry the response process.
+         */
+        suspend inline fun <reified C : Any> PipelineContext<Unit, ApplicationCall>.respond(response: Response<C>) {
+            call.respond(response.code, response.content)
+        }
+    }
+}

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/ServerTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/ServerTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server
+
+import io.kotest.core.spec.style.StringSpec
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import it.unibo.alchemist.server.modules.installModule
+import it.unibo.alchemist.server.modules.routingModule
+import it.unibo.alchemist.server.routes.mainRouteTest
+
+/**
+ * Test for Ktor Server.
+ */
+open class ServerTest : StringSpec({
+    "Server Routes should behave correctly" {
+        testApplication {
+            application {
+                installModule()
+                routingModule()
+            }
+            environment {
+                config = MapApplicationConfig(
+                    "ktor.deployment.port" to "80",
+                    "ktor.deployment.sslPort" to "7001"
+                )
+            }
+            mainRouteTest()
+        }
+    }
+})

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/routes/MainRouteTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/routes/MainRouteTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.routes
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.ApplicationTestBuilder
+
+suspend fun ApplicationTestBuilder.mainRouteTest() {
+    val response = client.get("/")
+    response.status shouldBe HttpStatusCode.OK
+    response.bodyAsText() shouldBe this::class.java.classLoader.getResource("index.html")?.readText()
+}

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/utility/ResponseTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/server/utility/ResponseTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpStatusCode.Companion.Conflict
+import io.ktor.http.HttpStatusCode.Companion.OK
+
+class ResponseTest : StringSpec({
+    "Responses code and content should be retrievable" {
+        val response = Response(OK, "Good.")
+        val intResponse = Response(Conflict, 1)
+        val doubleOkResponde = Response(content = 5.6)
+        response.code shouldBe OK
+        response.content shouldBe "Good."
+        intResponse.code shouldBe Conflict
+        intResponse.content shouldBe 1
+        doubleOkResponde.code shouldBe OK
+        doubleOkResponde.content shouldBe 5.6
+    }
+})


### PR DESCRIPTION
This PR includes the routes logic of the Web Renderer Server.

- **/environment/client**: responds with the Environment in serialized form;
- **/environment/server**: responds with the Environment in rendered form;
- **/simulation/status**: responds with the status of the Simulation;
- **/simulation/pause**: pauses the Simulation;
- **/simulation/play**: plays the Simulation;
- **/**: responds swith the index.html page.

_Note_: web socket could be used in the future, but the logic would remain more or less the same.