### PR TITLE
build(web-renderer): simplify shadowJar task configuration

### DIFF
--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -89,7 +89,9 @@ application {
 }
 
 tasks.getByName<JavaExec>("run") {
-    classpath(tasks.getByName<Jar>("shadowJar"))
+    val shadowJarTask = tasks.getByName<Jar>("shadowJar")
+    dependsOn(shadowJarTask)
+    classpath(shadowJarTask)
 }
 
 /**

--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -10,7 +10,6 @@
 import Libs.alchemist
 import Libs.incarnation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
 
 plugins {
     application
@@ -89,7 +88,7 @@ application {
 }
 
 tasks.getByName<JavaExec>("run") {
-    val shadowJarTask = tasks.getByName<Jar>("shadowJar")
+    val shadowJarTask = tasks.named("shadowJar").get()
     dependsOn(shadowJarTask)
     classpath(shadowJarTask)
 }
@@ -98,12 +97,12 @@ tasks.getByName<JavaExec>("run") {
  * Configure the [ShadowJar] task to work exactly like the "jvmJar" task of Kotlin Multiplatform, but also
  * include the JS artifacts by depending on the "jsBrowserProductionWebpack" task.
  */
-tasks.withType<ShadowJar> {
-    val jvmJarTask = tasks.getByName<Jar>("jvmJar")
-    val webpackTask = tasks.getByName<KotlinWebpack>("jsBrowserProductionWebpack")
+tasks.withType<ShadowJar>().configureEach {
+    val jvmJarTask = tasks.named("jvmJar").get()
+    val webpackTask = tasks.named("jsBrowserProductionWebpack").get()
     dependsOn(jvmJarTask, webpackTask)
     from(webpackTask.outputs.files)
-    from(jvmJarTask.archiveFile)
+    from(jvmJarTask.outputs.files)
     archiveClassifier.set("all")
 }
 

--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -87,6 +87,11 @@ application {
     mainClass.set("it.unibo.alchemist.Alchemist")
 }
 
+/**
+ * Webpack task that generates the JS artifacts.
+ */
+val webpackTask = tasks.named("jsBrowserProductionWebpack")
+
 tasks.getByName<JavaExec>("run") {
     val shadowJarTask = tasks.named("shadowJar").get()
     dependsOn(shadowJarTask)
@@ -98,11 +103,10 @@ tasks.getByName<JavaExec>("run") {
  * include the JS artifacts by depending on the "jsBrowserProductionWebpack" task.
  */
 tasks.withType<ShadowJar>().configureEach {
-    val jvmJarTask = tasks.named("jvmJar").get()
-    val webpackTask = tasks.named("jsBrowserProductionWebpack").get()
+    val jvmJarTask = tasks.named("jvmJar")
     dependsOn(jvmJarTask, webpackTask)
-    from(webpackTask.outputs.files)
-    from(jvmJarTask.outputs.files)
+    from(webpackTask)
+    from(jvmJarTask)
     archiveClassifier.set("all")
 }
 

--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -92,10 +92,16 @@ application {
  */
 val webpackTask = tasks.named("jsBrowserProductionWebpack")
 
-tasks.getByName<JavaExec>("run") {
-    val shadowJarTask = tasks.named("shadowJar").get()
-    dependsOn(shadowJarTask)
-    classpath(shadowJarTask)
+tasks.named("run", JavaExec::class) {
+    classpath(
+        tasks.named("compileKotlinJvm"),
+        configurations.named("jvmRuntimeClasspath"),
+        webpackTask.map { task ->
+            task.outputs.files.map { file ->
+                file.parent
+            }
+        }
+    )
 }
 
 /**


### PR DESCRIPTION
This PR is intended to simplify the alchemist-web-renderer build.

- The **shadowJar** task has been configured using a different strategy than before. The **jvmJar** task output (from Kotlin Multiplatform) is now used to generate a fat jar that includes the JVM classes. The **jsBrowserProductionWebpack** output is also included in the fat jar, like it was before these changes.
**_Note_**: The problem encountered in #1709 COULD be resolved with these changes. I believe the problem is caused by the use of the `finalizedBy` method. In this implementation, that use was completely removed.

- The run task now depends explicitly on the **shadowJar** task. This will ensure that the **shadowJar** task runs before the **run** task and that the output file of the **shadowJar** task is added to the classpath when the **run** task is executed.
