### PR TITLE
feat(web-renderer): add WebRendererLauncher, add (-w/--web) to AlchemistExecutionOptions

### DIFF
--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/launch/WebRendererLauncher.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/launch/WebRendererLauncher.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.launch
+
+import io.ktor.server.netty.EngineMain
+import it.unibo.alchemist.AlchemistExecutionOptions
+import it.unibo.alchemist.core.interfaces.Simulation
+import it.unibo.alchemist.loader.Loader
+import it.unibo.alchemist.server.state.ServerStore.store
+import it.unibo.alchemist.server.state.actions.SetSimulation
+import it.unibo.alchemist.server.monitor.EnvironmentMonitorFactory.makeEnvironmentMonitor
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * A launcher that starts a REST server to allow the visualization of the simulation on a Browser.
+ */
+object WebRendererLauncher : SimulationLauncher() {
+    override val name: String = "Web Renderer Launcher"
+
+    /**
+     * Check if the [it.unibo.alchemist.AlchemistExecutionOptions] is valid for this launcher.
+     * @param currentOptions the options to check.
+     * @return true if the options are valid, false otherwise.
+     */
+    override fun additionalValidation(currentOptions: AlchemistExecutionOptions): Validation =
+        with(currentOptions) {
+            when {
+                headless -> incompatibleWith("headless mode")
+                batch -> incompatibleWith("batch mode")
+                variables.isNotEmpty() -> incompatibleWith("variable exploration mode")
+                distributed != null -> incompatibleWith("distributed execution")
+                server != null -> incompatibleWith("Alchemist grid computing server mode")
+                graphics != null || fxui -> incompatibleWith("graphics mode")
+                web -> Validation.OK(Priority.High("Web Rendererer requested, priority shifts up"))
+                else -> Validation.OK()
+            }
+        }
+
+    /**
+     *  Prepares the simulation to be run, execute it in a coroutine and start the REST server by
+     *  executing [EngineMain] using the application.conf configuration file.
+     *  @param loader the loader of the simulation.
+     *  @param parameters the parameters of the simulation.
+     */
+    override fun launch(loader: Loader, parameters: AlchemistExecutionOptions) {
+        val simulation: Simulation<Any, Nothing> = prepareSimulation(loader, parameters, emptyMap<String, Any>())
+        store.dispatch(SetSimulation(simulation))
+        simulation.addOutputMonitor(makeEnvironmentMonitor(simulation.environment))
+        startServer(simulation)
+    }
+
+    private fun startServer(
+        simulation: Simulation<Any, Nothing>,
+        serverDispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) {
+        return runBlocking {
+            launch(serverDispatcher) {
+                EngineMain.main(emptyArray())
+            }
+            simulation.run()
+        }
+    }
+}

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/UtilityModule.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/modules/UtilityModule.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.server.modules
+
+import io.ktor.server.application.Application
+import java.net.InetAddress
+
+/**
+ * Start the default browser of the user on the server address.
+ */
+fun Application.startBrowserModule() {
+    Runtime.getRuntime().exec("xdg-open ${InetAddress.getLocalHost().hostAddress}:$port")
+}
+
+/**
+ * Retrieve the port used in the Ktor application.conf file.
+ */
+val Application.port get() = environment.config.property("ktor.deployment.port").getString().toInt()

--- a/alchemist-web-renderer/src/jvmMain/resources/application.conf
+++ b/alchemist-web-renderer/src/jvmMain/resources/application.conf
@@ -1,0 +1,20 @@
+# Copyright (C) 2010-2023, Danilo Pianini and contributors
+# listed, for each module, in the respective subproject's build.gradle.kts file.
+#
+# This file is part of Alchemist, and is distributed under the terms of the
+# GNU General Public License, with a linking exception,
+# as described in the file LICENSE in the Alchemist distribution's top directory.
+
+ktor {
+    deployment {
+        port = 9090
+        port = ${?PORT}
+    }
+    application {
+        modules = [
+            it.unibo.alchemist.server.modules.InstallModuleKt.installModule,
+            it.unibo.alchemist.server.modules.RoutingModuleKt.routingModule,
+            it.unibo.alchemist.server.modules.UtilityModuleKt.startBrowserModule
+        ]
+    }
+}

--- a/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/launch/WebRendererLauncherTest.kt
+++ b/alchemist-web-renderer/src/jvmTest/kotlin/it/unibo/alchemist/launch/WebRendererLauncherTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.AlchemistExecutionOptions
+import it.unibo.alchemist.launch.WebRendererLauncher
+import it.unibo.alchemist.launch.Validation
+
+class WebRendererLauncherTest : StringSpec(
+    {
+
+        val expectedLauncherName = "Web Renderer Launcher"
+
+        fun checkOptionsAreInvalid(options: AlchemistExecutionOptions, reason: String) {
+            WebRendererLauncher.validate(options) shouldBe Validation.Invalid(reason)
+        }
+
+        fun checkOptionsAreValid(options: AlchemistExecutionOptions) {
+            WebRendererLauncher.validate(options) shouldBe Validation.OK()
+        }
+
+        "WebRendererLauncher should have the correct name" {
+            WebRendererLauncher.name shouldBe expectedLauncherName
+        }
+
+        "Web Renderer Launcher is not compatible with distributed execution" {
+            checkOptionsAreInvalid(
+                AlchemistExecutionOptions(configuration = "placeholder", distributed = "something"),
+                "$expectedLauncherName is not compatible with distributed execution"
+            )
+        }
+
+        "Web Renderer Launcher is not compatible with graphics mode" {
+            checkOptionsAreInvalid(
+                AlchemistExecutionOptions(configuration = "placeholder", graphics = "something"),
+                "$expectedLauncherName is not compatible with graphics mode"
+            )
+            checkOptionsAreInvalid(
+                AlchemistExecutionOptions(configuration = "placeholder", fxui = true),
+                "$expectedLauncherName is not compatible with graphics mode"
+            )
+            checkOptionsAreInvalid(
+                AlchemistExecutionOptions(configuration = "placeholder", graphics = "something", fxui = true),
+                "$expectedLauncherName is not compatible with graphics mode"
+            )
+        }
+
+        "Web Renderer Launcher is not compatible with grid execution" {
+            checkOptionsAreInvalid(
+                AlchemistExecutionOptions(configuration = "placeholder", server = "something"),
+                "$expectedLauncherName is not compatible with Alchemist grid computing server mode"
+            )
+        }
+
+        "Web Renderer Launcher is not compatible with headless mode" {
+            checkOptionsAreInvalid(
+                AlchemistExecutionOptions(configuration = "placeholder", headless = true),
+                "$expectedLauncherName is not compatible with headless mode"
+            )
+        }
+
+        "Web Renderer Launcheris not compatible with variable exploration mode" {
+            checkOptionsAreInvalid(
+                AlchemistExecutionOptions(configuration = "placeholder", variables = listOf("something")),
+                "$expectedLauncherName is not compatible with variable exploration mode"
+            )
+        }
+
+        "Web Renderer Launcher can contain only configuration" {
+            checkOptionsAreValid(AlchemistExecutionOptions(configuration = "placeholder"))
+        }
+    }
+)

--- a/src/main/kotlin/it/unibo/alchemist/Alchemist.kt
+++ b/src/main/kotlin/it/unibo/alchemist/Alchemist.kt
@@ -43,6 +43,7 @@ object Alchemist {
     private const val PARALLELISM = 'p'
     private const val TIME = 't'
     private const val YAML = 'y'
+    private const val WEB = 'w'
     private val logger = LoggerFactory.getLogger(Alchemist::class.java)
     private val launchers: List<Launcher> = ClassPathScanner
         .subTypesOf(Launcher::class.java, "it.unibo.alchemist")
@@ -231,6 +232,7 @@ object Alchemist {
                 ?: AlchemistExecutionOptions.defaultEndTime,
             graphics = getOptionValue(GRAPHICS),
             fxui = hasOption(FXUI),
+            web = hasOption(WEB),
             headless = hasOption(HEADLESS),
             parallelism = hasNumeric(PARALLELISM, kotlin.String::toIntOrNull)
                 ?: AlchemistExecutionOptions.defaultParallelism,

--- a/src/main/kotlin/it/unibo/alchemist/AlchemistExecutionOptions.kt
+++ b/src/main/kotlin/it/unibo/alchemist/AlchemistExecutionOptions.kt
@@ -19,6 +19,7 @@ package it.unibo.alchemist
  * @property distributed the path to the file with the load distribution configuration, or null if the run is local
  * @property graphics the path to the effects file, or null if unspecified
  * @property fxui whether the JavaFX UI takes priority over the default Swing UI
+ * @property web true if the web renderer is used. Defaults to false.
  * @property help true if print help function is selected
  * @property server if launched as Alchemist grid node server, the path to the configuration file. Null otherwise.
  * @property parallelism parallel threads used for running locally. Defaults to [defaultParallelism]
@@ -32,6 +33,7 @@ data class AlchemistExecutionOptions(
     val distributed: String? = null,
     val graphics: String? = null,
     val fxui: Boolean = false,
+    val web: Boolean = false,
     val help: Boolean = false,
     val server: String? = null,
     val parallelism: Int = defaultParallelism,

--- a/src/main/resources/it/unibo/alchemist/cli/CLI.properties
+++ b/src/main/resources/it/unibo/alchemist/cli/CLI.properties
@@ -80,3 +80,6 @@ vv_description = Very verbose mode: prints debug-level informations. Slows the s
 
 vvv_longName = vvverbose
 vvv_description = Very very verbose mode: prints trace-level informations. Slows the simulator down. An awful lot.
+
+w_longName = web
+w_description = Runs the simulation using the Web Renderer


### PR DESCRIPTION
This PR includes the Launcher used by the Alchemist Web Renderer project. A KTOR configuration is also included, the ktor class MainEngine uses it to configure the Server with the modules already submitted. Finally, the w option shifts up the priority of the launcher if requested.