### PR TITLE
feat(web-renderer): add JS ReactBootstrap adapters

### DIFF
--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/Button.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/Button.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/Button")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.buttons
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap Button adapter.
+ * @see <a href="https://react-bootstrap.github.io/components/buttons/">
+ *     react-bootstrap - buttons</a>
+ */
+
+@JsName("default")
+external val Button: ComponentClass<ButtonProps>
+
+/**
+ * Props used to customize the Button.
+ */
+external interface ButtonProps : Props {
+
+    /**
+     * active prop, false by default.
+     */
+    var active: Boolean?
+
+    /**
+     * disable prop, false by default.
+     */
+    var disabled: Boolean?
+
+    /**
+     * variant prop, 'primary' by default.
+     */
+    var variant: String
+
+    /**
+     * onClick prop. Execute the specified function when clicked.
+     */
+    var onClick: () -> Unit
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButton.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButton.kt
@@ -16,7 +16,7 @@ import react.ComponentClass
 import react.Props
 
 /**
- * React Bootstrap ToggleButton adapter
+ * React Bootstrap ToggleButton adapter.
  * @see <a href="https://react-bootstrap.github.io/components/buttons/">
  *     react-bootstrap - buttons</a>
  */

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButton.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButton.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/ToggleButton")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.buttons
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap ToggleButton adapter
+ * @see <a href="https://react-bootstrap.github.io/components/buttons/">
+ *     react-bootstrap - buttons</a>
+ */
+
+@JsName("default")
+external val ToggleButton: ComponentClass<ToggleButtonProps>
+
+/**
+ * Props used to customize the ToggleButton.
+ */
+external interface ToggleButtonProps : Props {
+
+    /**
+     * id props, required.
+     */
+    var id: String
+
+    /**
+     * value props.
+     */
+    var value: Any
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButtonGroup.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButtonGroup.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/ToggleButtonGroup")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.buttons
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap ToggleButtonGroup adapter
+ * @see <a href="https://react-bootstrap.github.io/components/buttons/">
+ *     react-bootstrap - buttons</a>
+ */
+
+@JsName("default")
+external val ToggleButtonGroup: ComponentClass<ToggleButtonGroupProps>
+
+/**
+ * Props used to customize the ToggleButtonGroup.
+ */
+external interface ToggleButtonGroupProps : Props {
+    /**
+     * type prop, 'checkbox' | 'radio'.
+     */
+    var type: String
+
+    /**
+     * size prop to choose buttons size, 'sm' | 'lg'.
+     */
+    var size: String
+
+    /**
+     * name prop.
+     */
+    var name: String
+
+    /**
+     * onChange prop, callback function.
+     */
+    var onChange: (Any) -> Unit
+
+    /**
+     * defaultValue prop.
+     */
+    var defaultValue: Any
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButtonGroup.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/buttons/ToggleButtonGroup.kt
@@ -16,7 +16,7 @@ import react.ComponentClass
 import react.Props
 
 /**
- * React Bootstrap ToggleButtonGroup adapter
+ * React Bootstrap ToggleButtonGroup adapter.
  * @see <a href="https://react-bootstrap.github.io/components/buttons/">
  *     react-bootstrap - buttons</a>
  */

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/Modal.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/Modal.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/Modal")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.modal
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap Modal adapter.
+ * @see <a href="https://react-bootstrap.github.io/components/modal">
+ *     react-bootstrap - modal</a>
+ */
+
+@JsName("default")
+external val Modal: ComponentClass<ModalProps>
+
+/**
+ * Props used to customize the Modal.
+ */
+external interface ModalProps : Props {
+    /**
+     * show prop, false by default.
+     */
+    var show: Boolean?
+
+    /**
+     * onHide prop. Execute the specified function when the hide button is clicked.
+     */
+    var onHide: () -> Unit
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalBody.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalBody.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/ModalBody")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.modal
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap ModalBody adapter.
+ * @see <a href="https://react-bootstrap.github.io/components/modal">
+ *     react-bootstrap - modal</a>
+ */
+
+@JsName("default")
+external val ModalBody: ComponentClass<Props>

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalFooter.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalFooter.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/ModalFooter")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.modal
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap ModalFooter adapter.
+ * @see <a href="https://react-bootstrap.github.io/components/modal">
+ *     react-bootstrap - modal</a>
+ */
+
+@JsName("default")
+external val ModalFooter: ComponentClass<Props>

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalHeader.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalHeader.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/ModalHeader")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.modal
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap ModalHeader adapter.
+ * @see <a href="https://react-bootstrap.github.io/components/modal">
+ *     react-bootstrap - modal</a>
+ */
+
+@JsName("default")
+external val ModalHeader: ComponentClass<ModalHeaderProps>
+
+/**
+ * Props used to customize the ModalHeader.
+ */
+external interface ModalHeaderProps : Props {
+    /**
+     * closeButton prop.
+     */
+    var closeButton: Boolean?
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalTitle.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/modal/ModalTitle.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/ModalTitle")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.modal
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap ModalTitle adapter.
+ * @see <a href="https://react-bootstrap.github.io/components/modal">
+ *     react-bootstrap - modal</a>
+ */
+
+@JsName("default")
+external val ModalTitle: ComponentClass<ModalTitleProps>
+
+/**
+ * Props used to customize the ModalHeader.
+ */
+external interface ModalTitleProps : Props {
+    /**
+     * className prop. Useful for customizing.
+     */
+    var className: String
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/navbar/Navbar.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/navbar/Navbar.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+@file:JsModule("react-bootstrap/Navbar")
+@file:JsNonModule
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.navbar
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * React Bootstrap Navbar adapter.
+ * @see <a href="https://react-bootstrap.github.io/components/navbar/">react-bootstrap - navbar</a>
+ */
+@JsName("default")
+external val Navbar: ComponentClass<NavbarProps>
+
+/**
+ * Props used to customize the Navbar.
+ */
+external interface NavbarProps : Props {
+    /**
+     * bg props.
+     */
+    var bg: String
+
+    /**
+     * variant props.
+     */
+    var variant: String
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/navbar/Navbar.ktx.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/adapters/reactBootstrap/navbar/Navbar.ktx.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.adapters.reactBootstrap.navbar
+
+import react.ComponentClass
+import react.Props
+
+/**
+ * Navbar.Brand component.
+ * Note: an explicit cast is required here, as the original Javascript structure is dynamic.
+ */
+@Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+val NavbarBrand: ComponentClass<Props> = Navbar.asDynamic().Brand as ComponentClass<Props>


### PR DESCRIPTION
In this PR all the JS adapters of the Alchemist Web Renderer project are added at once.
To use npm dependencies in Kotlin, a sort of adapter is needed, because JavaScript modules are usually dynamically typed while Kotlin is a statically typed language.

The added adapters are for the components of the famous [React Bootstrap](https://react-bootstrap.github.io/) library.

[For more informations about npm dependencies in Kotlin](https://kotlinlang.org/docs/using-packages-from-npm.html)