### PR TITLE
feat(web-renderer): add Client State

### DIFF
--- a/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Action.kt
+++ b/alchemist-web-renderer/src/commonMain/kotlin/it/unibo/alchemist/common/utility/Action.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.utility
+
+/**
+ * Actions that can be performed on a simulation.
+ */
+enum class Action {
+
+    /**
+     * The action used to start the Simulation.
+     */
+    PLAY,
+
+    /**
+     * The action used to pause the Simulation.
+     */
+    PAUSE;
+}

--- a/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/utility/ActionTest.kt
+++ b/alchemist-web-renderer/src/commonTest/kotlin/it/unibo/alchemist/common/utility/ActionTest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.common.utility
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ActionTest : StringSpec({
+    "SimulationAction are PLAY and PAUSE" {
+        val actions = Action.values()
+        actions.size shouldBe 2
+        actions.map { it }.containsAll(listOf(Action.PLAY, Action.PAUSE)) shouldBe true
+    }
+})

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/ClientState.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/ClientState.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state
+
+import com.soywiz.korim.bitmap.Bitmap
+import it.unibo.alchemist.client.state.reducers.bitmapReducer
+import it.unibo.alchemist.client.state.reducers.playButtonReducer
+import it.unibo.alchemist.client.state.reducers.renderModeReducer
+import it.unibo.alchemist.client.state.reducers.statusSurrogateReducer
+import it.unibo.alchemist.common.model.RenderMode
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+import it.unibo.alchemist.common.utility.Action
+import it.unibo.alchemist.common.state.CommonState
+
+/**
+ * The state of the client.
+ * The [ClientState] is managed using the
+ * <a href="https://reduxkotlin.org/introduction/core-concepts">Core concepts of the ReduxKotlin library</a>.
+ * Like in the original Redux library the state is stored in a single class that contains other objects via composition.
+ * The state can be changed using actions that must be defined in advance.
+ * The unique store that encapsulate the [ClientState] is {@link it.unibo.alchemist.client.state.ClientStore}.
+ * @param renderMode the render mode of the client.
+ * It can be either client, server or auto. It is set to auto by default.
+ * @param playButton the state of the play button.
+ * @param bitmap the bitmap to display.
+ * @param statusSurrogate the [StatusSurrogate] of the simulation.
+ * @see <a href="https://reduxkotlin.org/">ReduxKotlin Documentation</a>
+ */
+data class ClientState(
+    val renderMode: RenderMode = RenderMode.AUTO,
+    val playButton: Action = Action.PAUSE,
+    val bitmap: Bitmap? = null,
+    val statusSurrogate: StatusSurrogate = StatusSurrogate.INIT
+) : CommonState()
+
+/**
+ * Root reducer of the client. Uses all the other reducers.
+ * @param state the current state of the application.
+ * @param action the action to perform.
+ * @return the new state of the application.
+ */
+fun rootReducer(state: ClientState, action: Any): ClientState = ClientState(
+    renderMode = renderModeReducer(state.renderMode, action),
+    playButton = playButtonReducer(state.playButton, action),
+    bitmap = bitmapReducer(state.bitmap, action),
+    statusSurrogate = statusSurrogateReducer(state.statusSurrogate, action)
+)

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/ClientStore.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/ClientStore.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.createStore
+
+/**
+ * The store of the client.
+ * This class uses the core concepts of the original Redux library.
+ * Thanks to the singleton pattern, the [ClientState] can be accessed or edited from anywhere.
+ * @see <a href="https://reduxkotlin.org/">ReduxKotlin Documentation</a>
+ */
+object ClientStore {
+
+    /**
+     * The redux store of the client.
+     */
+    val store: Store<ClientState> = createStore(::rootReducer, ClientState())
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetBitmap.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetBitmap.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.actions
+
+import com.soywiz.korim.bitmap.Bitmap
+
+/**
+ * Redux action to set the bitmap to display.
+ * @param bitmap the new bitmap to set.
+ */
+data class SetBitmap(val bitmap: Bitmap?)

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetPlayButton.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetPlayButton.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.actions
+
+import it.unibo.alchemist.common.utility.Action
+
+/**
+ * Redux action to set the Simulation state of the application and switch between Play and pause.
+ * @param action the new simulation action to set.
+ */
+data class SetPlayButton(val action: Action)

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetRenderMode.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetRenderMode.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.actions
+
+import it.unibo.alchemist.common.model.RenderMode
+
+/**
+ * Redux action to set the Render Mode of the application.
+ * @param renderMode the new render mode.
+ */
+data class SetRenderMode(val renderMode: RenderMode)

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetStatusSurrogate.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/actions/SetStatusSurrogate.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.actions
+
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+
+/**
+ * Redux action to set the [StatusSurrogate] of the application.
+ * @param statusSurrogate the new [StatusSurrogate].
+ */
+data class SetStatusSurrogate(val statusSurrogate: StatusSurrogate)

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/BitmapReducer.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/BitmapReducer.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.reducers
+
+import com.soywiz.korim.bitmap.Bitmap
+import it.unibo.alchemist.client.state.actions.SetBitmap
+
+/**
+ * Reducer for the bitmap.
+ * @param state the current bitmap state.
+ * @param action the action to perform.
+ * @return the new bitmap.
+ */
+fun bitmapReducer(state: Bitmap?, action: Any): Bitmap? = when (action) {
+    is SetBitmap -> action.bitmap
+    else -> state
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/PlayButtonReducer.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/PlayButtonReducer.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.reducers
+
+import it.unibo.alchemist.common.utility.Action
+import it.unibo.alchemist.client.state.actions.SetPlayButton
+
+/**
+ * Reducer for the simulation play button.
+ * @param simulationAction the current simulation play button state.
+ * @param action the action to perform.
+ * @return the new simulation play button state.
+ */
+fun playButtonReducer(simulationAction: Action, action: Any): Action = when (action) {
+    is SetPlayButton -> action.action
+    else -> simulationAction
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/RenderModeReducer.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/RenderModeReducer.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.reducers
+
+import it.unibo.alchemist.common.model.RenderMode
+import it.unibo.alchemist.client.state.actions.SetRenderMode
+
+/**
+ * Reducer for the render mode.
+ * @param state the current render mode state.
+ * @param action the action to perform.
+ * @return the new render mode.
+ */
+fun renderModeReducer(state: RenderMode, action: Any): RenderMode = when (action) {
+    is SetRenderMode -> action.renderMode
+    else -> state
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/StatusSurrogateReducer.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/state/reducers/StatusSurrogateReducer.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state.reducers
+
+import it.unibo.alchemist.client.state.actions.SetStatusSurrogate
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+
+/**
+ * Reducer for the [StatusSurrogate].
+ * @param state the current [StatusSurrogate].
+ * @param action the action to perform.
+ * @return the new [StatusSurrogate].
+ */
+fun statusSurrogateReducer(state: StatusSurrogate, action: Any): StatusSurrogate = when (action) {
+    is SetStatusSurrogate -> action.statusSurrogate
+    else -> state
+}

--- a/alchemist-web-renderer/src/jsTest/kotlin/it/unibo/alchemist/client/state/ClientStoreTest.kt
+++ b/alchemist-web-renderer/src/jsTest/kotlin/it/unibo/alchemist/client/state/ClientStoreTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.state
+
+import com.soywiz.korim.bitmap.Bitmap32
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.client.state.actions.SetBitmap
+import it.unibo.alchemist.client.state.actions.SetPlayButton
+import it.unibo.alchemist.client.state.actions.SetRenderMode
+import it.unibo.alchemist.client.state.actions.SetStatusSurrogate
+import it.unibo.alchemist.common.model.RenderMode
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+import it.unibo.alchemist.common.utility.Action
+import org.reduxkotlin.Store
+import org.reduxkotlin.createStore
+
+class ClientStoreTest : StringSpec({
+
+    val clientStore: Store<ClientState> = createStore(::rootReducer, ClientState())
+
+    "ClientStore should have a default configuration at the beginning" {
+        clientStore.state.playButton shouldBe Action.PAUSE
+        clientStore.state.renderMode shouldBe RenderMode.AUTO
+        clientStore.state.bitmap shouldBe null
+        clientStore.state.statusSurrogate shouldBe StatusSurrogate.INIT
+    }
+
+    "ClientStore can be updated with a SetPlayButton action" {
+        listOf(Action.PLAY, Action.PAUSE).forEach {
+            clientStore.dispatch(SetPlayButton(it))
+            clientStore.state.playButton shouldBe it
+        }
+    }
+
+    "ClientStore can be updated with a SetRenderMode action" {
+        listOf(RenderMode.CLIENT, RenderMode.SERVER, RenderMode.AUTO).forEach {
+            clientStore.dispatch(SetRenderMode(it))
+            clientStore.state.renderMode shouldBe it
+        }
+    }
+
+    "ClientStore can be updated with a SetBitmap action" {
+        listOf(Bitmap32(1, 1, premultiplied = false), Bitmap32(2, 2, premultiplied = false)).forEach {
+            clientStore.dispatch(SetBitmap(it))
+            clientStore.state.bitmap shouldBe it
+        }
+    }
+
+    "ClientStore can be updated with a SetRenderMode action" {
+        listOf(
+            StatusSurrogate.READY,
+            StatusSurrogate.PAUSED,
+            StatusSurrogate.RUNNING,
+            StatusSurrogate.TERMINATED,
+            StatusSurrogate.INIT
+        ).forEach {
+            clientStore.dispatch(SetStatusSurrogate(it))
+            clientStore.state.statusSurrogate shouldBe it
+        }
+    }
+})


### PR DESCRIPTION
This PR includes the Client State relative classes. These are the classes used to manage the state of the web app. The management of the state works exactly like already explained in the Server State classes. Documentation has also been added in the comments accordingly.