### PR TITLE
feat(web-renderer): add APIs and internal Logic in Client (jsMain)

### DIFF
--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/EnvironmentApi.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/EnvironmentApi.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.api
+
+import com.soywiz.korim.bitmap.Bitmap
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import it.unibo.alchemist.client.api.utility.JsonClient.client
+import it.unibo.alchemist.client.api.utility.JsonClient.endpoint
+import it.unibo.alchemist.common.model.serialization.decodeEnvironmentSurrogate
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import it.unibo.alchemist.common.renderer.Bitmap32Serializer
+import it.unibo.alchemist.common.utility.Routes
+
+/**
+ * API to retrieve the Environment of the simulation.
+ */
+object EnvironmentApi {
+
+    /**
+     * Get the environment of the simulation in a serialized form.
+     * The client will use this to render the environment.
+     * @return the [EnvironmentSurrogate] retrieved by the server.
+     */
+    suspend fun getEnvironmentClient(): EnvironmentSurrogate<Any, PositionSurrogate> =
+        jsonFormat.decodeEnvironmentSurrogate(getEnvironment(Routes.environmentClientPath))
+
+    /**
+     * Get the environment of the simulation, already rendered by the server.
+     * @return the [Bitmap] corresponding to the rendered environment.
+     */
+    suspend fun getEnvironmentServer(): Bitmap =
+        jsonFormat.decodeFromString(Bitmap32Serializer, getEnvironment(Routes.environmentServerPath))
+
+    /**
+     * Get the environment of the simulation in the form proposed by the path of retrieval.
+     * @param path the path of the environment retrieval.
+     * @param <B> the type of the body of the response.
+     */
+    private suspend inline fun <reified B> getEnvironment(path: String): B {
+        return client.get(endpoint + path).body()
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/SimulationApi.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/SimulationApi.kt
@@ -23,7 +23,7 @@ import it.unibo.alchemist.common.utility.Routes
 object SimulationApi {
 
     /**
-     * Get the simulation status as a [StatusSurrogate]
+     * Get the simulation status as a [StatusSurrogate].
      */
     suspend fun getSimulationStatus(): StatusSurrogate {
         return client.get(endpoint + Routes.simulationStatusPath).body()

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/SimulationApi.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/SimulationApi.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.api
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import it.unibo.alchemist.client.api.utility.JsonClient.client
+import it.unibo.alchemist.client.api.utility.JsonClient.endpoint
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+import it.unibo.alchemist.common.utility.Routes
+
+/**
+ * API to interact with the simulation using the Play Button.
+ */
+object SimulationApi {
+
+    /**
+     * Get the simulation status as a [StatusSurrogate]
+     */
+    suspend fun getSimulationStatus(): StatusSurrogate {
+        return client.get(endpoint + Routes.simulationStatusPath).body()
+    }
+
+    /**
+     * Plays the simulation.
+     */
+    suspend fun playSimulation(): HttpResponse {
+        return client.post(endpoint + Routes.simulationPlayPath)
+    }
+
+    /**
+     * Pauses the simulation.
+     */
+    suspend fun pauseSimulation(): HttpResponse {
+        return client.post(endpoint + Routes.simulationPausePath)
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/utility/JsonClient.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/api/utility/JsonClient.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.api.utility
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import it.unibo.alchemist.common.model.serialization.jsonFormat
+import kotlinx.browser.window
+
+/**
+ * Client used to make API call to the server.
+ */
+object JsonClient {
+
+    /**
+     * Ktor endpoint. Used by the client to make API calls.
+     */
+    val endpoint: String = window.location.origin
+
+    /**
+     * Http client that will make the API call.
+     */
+    val client: HttpClient = HttpClient {
+        install(ContentNegotiation) {
+            json(jsonFormat)
+        }
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/AutoRenderModeStrategy.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/AutoRenderModeStrategy.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.logic
+
+import it.unibo.alchemist.common.model.RenderMode
+import kotlinx.browser.window
+
+/**
+ *  A strategy to assign what [RenderMode] is selected if [RenderMode.AUTO] is selected.
+ *  This interface could implement () -> RenderMode but this is prohibited in Kotlin/JS.
+ */
+interface AutoRenderModeStrategy {
+    /**
+     * @return the correct [RenderMode].
+     */
+    operator fun invoke(): RenderMode
+}
+
+/**
+ * The render mode is selected based on the hardware capacity of the client.
+ * @param minHwConcurrency the recommended number of core to use for the Auto mode.
+ * @return [RenderMode.CLIENT] if the hardware capacity is above the parameters, [RenderMode.SERVER] otherwise.
+ */
+data class HwAutoRenderModeStrategy(val minHwConcurrency: Int = 4) : AutoRenderModeStrategy {
+    override fun invoke(): RenderMode = if (window.navigator.hardwareConcurrency.toInt() > minHwConcurrency) {
+        RenderMode.CLIENT
+    } else {
+        RenderMode.SERVER
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/RESTUpdateStateStrategy.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/RESTUpdateStateStrategy.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.logic
+
+import com.soywiz.korim.bitmap.Bitmap
+import com.soywiz.korio.async.launch
+import it.unibo.alchemist.client.api.EnvironmentApi
+import it.unibo.alchemist.client.api.SimulationApi.getSimulationStatus
+import it.unibo.alchemist.client.state.ClientStore.store
+import it.unibo.alchemist.client.state.actions.SetBitmap
+import it.unibo.alchemist.client.state.actions.SetStatusSurrogate
+import it.unibo.alchemist.common.model.surrogate.EnvironmentSurrogate
+import it.unibo.alchemist.common.model.surrogate.PositionSurrogate
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Update the application state using HTTP calls to the REST server.
+ */
+class RESTUpdateStateStrategy : UpdateStateStrategy {
+
+    /**
+     * Retrieve the Environment in serialized form using the [EnvironmentApi].
+     * The Environment will be rendered and saved in the [it.unibo.alchemist.client.state.ClientStore].
+     */
+    override suspend fun clientComputation() {
+        val environment: EnvironmentSurrogate<Any, PositionSurrogate> = EnvironmentApi.getEnvironmentClient()
+        launch(Dispatchers.Default) {
+            storeBitmap(store.state.renderer.render(environment))
+        }
+    }
+
+    /**
+     * Retrieve the Environment in already rendered form using the [EnvironmentApi].
+     * Decode it and save it in the [it.unibo.alchemist.client.state.ClientStore].
+     */
+    override suspend fun serverComputation() {
+        storeBitmap(EnvironmentApi.getEnvironmentServer())
+    }
+
+    /**
+     * Retrieve the Simulation Status as a [it.unibo.alchemist.common.model.surrogate.StatusSurrogate], then save it in
+     * the [it.unibo.alchemist.client.state.ClientStore].
+     */
+    override suspend fun retrieveSimulationStatus() {
+        store.dispatch(SetStatusSurrogate(getSimulationStatus()))
+    }
+
+    private fun storeBitmap(bitmap: Bitmap) {
+        store.dispatch(SetBitmap(bitmap))
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/UpdateState.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/UpdateState.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.logic
+
+import it.unibo.alchemist.client.state.ClientStore.store
+import it.unibo.alchemist.common.model.RenderMode
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+
+/**
+ * Update the application state, including the Environment.
+ * @param renderMode the render mode set by the user.
+ * @param updateStateStrategy the [UpdateStateStrategy] to use.
+ * @param autoStrategy the [AutoRenderModeStrategy] to use.
+ */
+suspend fun updateState(
+    renderMode: RenderMode,
+    updateStateStrategy: UpdateStateStrategy,
+    autoStrategy: AutoRenderModeStrategy
+) {
+    updateStateStrategy.retrieveSimulationStatus()
+    if (store.state.statusSurrogate == StatusSurrogate.RUNNING || store.state.bitmap == null) {
+        updateEnvironment(renderMode, updateStateStrategy, autoStrategy)
+    }
+}
+
+/**
+ * Update the state of the Environment.
+ * @param renderMode the render mode set by the user.
+ * @param updateStateStrategy the [UpdateStateStrategy] to use.
+ * @param autoStrategy the [AutoRenderModeStrategy] to use.
+ */
+private suspend fun updateEnvironment(
+    renderMode: RenderMode,
+    updateStateStrategy: UpdateStateStrategy,
+    autoStrategy: AutoRenderModeStrategy
+): Unit = when (renderMode) {
+    RenderMode.CLIENT -> updateStateStrategy.clientComputation()
+    RenderMode.SERVER -> updateStateStrategy.serverComputation()
+    RenderMode.AUTO -> updateEnvironment(
+        autoStrategy(),
+        updateStateStrategy,
+        object : AutoRenderModeStrategy {
+            override fun invoke(): RenderMode = error("Auto mode cannot be returned here.")
+        }
+    )
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/UpdateStateStrategy.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/logic/UpdateStateStrategy.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.logic
+
+/**
+ * The strategy used to update the application state. This class is mainly used to specify how the application
+ * should behave based on the state of the [it.unibo.alchemist.common.model.RenderMode].
+ */
+interface UpdateStateStrategy {
+
+    /**
+     * Update the application state, the client will do most of the computation.
+     */
+    suspend fun clientComputation()
+
+    /**
+     * Update the application state, the server will do most of the computation.
+     */
+    suspend fun serverComputation()
+
+    /**
+     * Retrieve the simulation status from the simulation and update the application state.
+     */
+    suspend fun retrieveSimulationStatus()
+}

--- a/alchemist-web-renderer/src/jsTest/kotlin/it/unibo/alchemist/client/logic/UpdateStateTest.kt
+++ b/alchemist-web-renderer/src/jsTest/kotlin/it/unibo/alchemist/client/logic/UpdateStateTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.logic
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import it.unibo.alchemist.common.model.RenderMode
+
+class UpdateStateTest : StringSpec({
+
+    var clientCount = 0
+    var serverCount = 0
+    var statusCount = 0
+
+    val updateStateStrategy = object : UpdateStateStrategy {
+        override suspend fun clientComputation() {
+            clientCount++
+        }
+
+        override suspend fun serverComputation() {
+            serverCount++
+        }
+
+        override suspend fun retrieveSimulationStatus() {
+            statusCount++
+        }
+    }
+
+    val autoStrategy = object : AutoRenderModeStrategy {
+        override fun invoke(): RenderMode =
+            if (clientCount >= serverCount) {
+                RenderMode.SERVER
+            } else {
+                RenderMode.CLIENT
+            }
+    }
+
+    val brokenAutoStrategy = object : AutoRenderModeStrategy {
+        override fun invoke(): RenderMode = RenderMode.AUTO
+    }
+
+    "updateState should work using RenderMode.SERVER" {
+        updateState(RenderMode.SERVER, updateStateStrategy, autoStrategy)
+        statusCount shouldBe 1
+        clientCount shouldBe 0
+        serverCount shouldBe 1
+    }
+
+    "updateState should work using RenderMode.CLIENT" {
+        updateState(RenderMode.CLIENT, updateStateStrategy, autoStrategy)
+        statusCount shouldBe 2
+        clientCount shouldBe 1
+        serverCount shouldBe 1
+    }
+
+    "updateState should work using RenderMode.AUTO" {
+        updateState(RenderMode.AUTO, updateStateStrategy, autoStrategy)
+        statusCount shouldBe 3
+        clientCount shouldBe 1
+        serverCount shouldBe 2
+    }
+
+    "updateState should launch Exception using a broken autoStrategy" {
+        shouldThrow<IllegalStateException> {
+            updateState(RenderMode.AUTO, updateStateStrategy, brokenAutoStrategy)
+        }
+    }
+})


### PR DESCRIPTION
In this PR the following features are included:

- APIs to interact with the JVM server (mostly consists of asynchronous methods that make requests to endpoints);
- Some classes used for managing the internal logic of the JS project. The `updateState` top-level function uses all of them to update the internal state and rendering the content on the page accordingly.