### PR TITLE
feat(web-renderer): add React Components for front-end Structure

### DIFF
--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/Client.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/Client.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client
+
+import it.unibo.alchemist.client.components.AppContent
+import it.unibo.alchemist.client.components.AppNavbar
+import kotlinx.browser.document
+import react.FC
+import react.Props
+import react.create
+import react.dom.client.createRoot
+import web.dom.Element
+
+/**
+ * The entry point of the Kotlin/JS application. Find the root element and render the App.
+ */
+fun main() {
+    val container = document.getElementById("root") ?: error("Couldn't find container!")
+    createRoot(container.unsafeCast<Element>()).render(App.create())
+}
+
+/**
+ * The App to render.
+ */
+val App: FC<Props> = FC {
+    AppNavbar()
+    AppContent()
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/AppContent.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/AppContent.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.components
+
+import com.soywiz.korim.bitmap.Bitmap
+import com.soywiz.korim.format.toHtmlNative
+import it.unibo.alchemist.client.logic.HwAutoRenderModeStrategy
+import it.unibo.alchemist.client.logic.RESTUpdateStateStrategy
+import it.unibo.alchemist.client.logic.updateState
+import it.unibo.alchemist.client.state.ClientStore.store
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.img
+import react.useState
+import web.timers.setInterval
+import kotlin.time.Duration
+
+private val scope = MainScope()
+
+/**
+ * The application main content section.
+ */
+val AppContent: FC<Props> = FC {
+
+    val intervalDuration = "5s"
+    var bitmap: Bitmap? by useState(null)
+
+    store.subscribe {
+        bitmap = store.state.bitmap
+    }
+
+    setInterval(Duration.parse(intervalDuration)) {
+        scope.launch {
+            updateState(store.state.renderMode, RESTUpdateStateStrategy(), HwAutoRenderModeStrategy())
+        }
+    }
+
+    div {
+        img {
+            src = bitmap?.toHtmlNative()?.lazyCanvasElement?.toDataURL()
+        }
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/AppNavbar.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/AppNavbar.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.components
+
+import react.FC
+import react.Props
+import it.unibo.alchemist.client.adapters.reactBootstrap.navbar.Navbar
+import it.unibo.alchemist.client.adapters.reactBootstrap.navbar.NavbarBrand
+import it.unibo.alchemist.client.state.ClientStore.store
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+import react.useState
+
+/**
+ * The application Navbar.
+ */
+val AppNavbar: FC<Props> = FC {
+
+    var statusSurrogate: StatusSurrogate by useState { StatusSurrogate.INIT }
+
+    store.subscribe {
+        statusSurrogate = store.state.statusSurrogate
+    }
+
+    Navbar {
+        bg = "dark"
+        variant = "dark"
+        NavbarBrand {
+            +"Alchemist Web Renderer"
+        }
+        RenderModeButtons()
+        PlayButton {
+            status = statusSurrogate
+        }
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/PlayButton.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/PlayButton.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.components
+
+import io.ktor.client.call.body
+import io.ktor.http.HttpStatusCode
+import it.unibo.alchemist.common.utility.Action.PLAY
+import it.unibo.alchemist.common.utility.Action.PAUSE
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import react.FC
+import react.Props
+import it.unibo.alchemist.client.adapters.reactBootstrap.buttons.Button
+import it.unibo.alchemist.client.api.SimulationApi.pauseSimulation
+import it.unibo.alchemist.client.api.SimulationApi.playSimulation
+import react.useState
+import it.unibo.alchemist.client.state.ClientStore.store
+import it.unibo.alchemist.client.state.actions.SetPlayButton
+import it.unibo.alchemist.common.model.surrogate.StatusSurrogate
+
+private val scope = MainScope()
+
+/**
+ * Props for the [it.unibo.alchemist.client.components.PlayButtonKt.getPlayButton] component.
+ */
+external interface PlayButtonProps : Props {
+    /**
+     * Status of the simulation.
+     */
+    var status: StatusSurrogate
+}
+
+/**
+ * Play Button component. Used to start and pause the simulation.
+ */
+val PlayButton: FC<PlayButtonProps> = FC { props ->
+
+    var showWarningModal: Boolean by useState(false)
+    var warningModalTitle: String by useState { "" }
+    var warningModalMessage: String by useState { "" }
+
+    val isSimulationRunning: (StatusSurrogate) -> Boolean = { status ->
+        when (status) {
+            StatusSurrogate.RUNNING -> true
+            else -> false
+        }
+    }
+
+    Button {
+        disabled = when (props.status) {
+            StatusSurrogate.INIT -> true
+            StatusSurrogate.TERMINATED -> true
+            else -> false
+        }
+        variant = if (isSimulationRunning(props.status)) "danger" else "success"
+        onClick = {
+            scope.launch {
+                val response = if (isSimulationRunning(props.status)) pauseSimulation() else playSimulation()
+                if (response.status == HttpStatusCode.OK) {
+                    store.dispatch(
+                        SetPlayButton(if (isSimulationRunning(props.status)) PLAY else PAUSE)
+                    )
+                } else {
+                    warningModalTitle = "Error ${response.status}"
+                    warningModalMessage = response.body() ?: "Unknown error"
+                    showWarningModal = true
+                }
+            }
+        }
+        +if (isSimulationRunning(props.status)) "Pause" else "Play"
+    }
+
+    WarningModal {
+        show = showWarningModal
+        onHide = { showWarningModal = false }
+        title = warningModalTitle
+        message = warningModalMessage
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/RenderModeButtons.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/RenderModeButtons.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.components
+
+import it.unibo.alchemist.common.model.RenderMode
+import react.FC
+import react.Props
+import it.unibo.alchemist.client.adapters.reactBootstrap.buttons.ToggleButton
+import it.unibo.alchemist.client.adapters.reactBootstrap.buttons.ToggleButtonGroup
+import it.unibo.alchemist.client.state.ClientStore.store
+import it.unibo.alchemist.client.state.actions.SetRenderMode
+
+/**
+ * The button group that let the user decide which render mode to use.
+ */
+val RenderModeButtons: FC<Props> = FC {
+    ToggleButtonGroup {
+        name = "toggle-render-mode"
+        onChange = { value ->
+            store.dispatch(SetRenderMode(value as RenderMode))
+        }
+        defaultValue = RenderMode.AUTO
+        ToggleButton {
+            id = "client-button"
+            value = RenderMode.CLIENT
+            +"Client"
+        }
+        ToggleButton {
+            id = "auto-button"
+            value = RenderMode.AUTO
+            +"Auto"
+        }
+        ToggleButton {
+            id = "server-button"
+            value = RenderMode.SERVER
+            +"Server"
+        }
+    }
+}

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/WarningModal.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/WarningModal.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2010-2022, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.client.components
+
+import react.FC
+import it.unibo.alchemist.client.adapters.reactBootstrap.modal.Modal
+import it.unibo.alchemist.client.adapters.reactBootstrap.modal.ModalBody
+import it.unibo.alchemist.client.adapters.reactBootstrap.modal.ModalHeader
+import it.unibo.alchemist.client.adapters.reactBootstrap.modal.ModalProps
+import it.unibo.alchemist.client.adapters.reactBootstrap.modal.ModalTitle
+
+/**
+ * Modal used to show information about something that didn't work as expected.
+ */
+val WarningModal: FC<WarningModalProps> = FC { props ->
+    Modal {
+        show = props.show
+        onHide = props.onHide
+        ModalHeader {
+            closeButton = true
+            ModalTitle {
+                className = "text-danger"
+                +props.title
+            }
+        }
+        ModalBody {
+            +props.message
+        }
+    }
+}
+
+/**
+ * Props used to customize the WarningModal.
+ */
+external interface WarningModalProps : ModalProps {
+    /**
+     * Title of the Modal.
+     */
+    var title: String
+
+    /**
+     * Message of the Modal.
+     */
+    var message: String
+}


### PR DESCRIPTION
This PR contains all the components of the client application.
These components are used to create the structure of the web page and works exactly like [React original components](https://reactjs.org/docs/components-and-props.html). In terms of declarations, there are some similarities with the [Typesafe HTML DSL](https://kotlinlang.org/docs/typesafe-html-dsl.html).