### PR TITLE
fix(ci): add uploadJvm and uploadJs to publishCmd

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,8 @@ git -C build/website/ add . || exit 1
 git -C build/website/ commit -m "chore: update website to version \${nextRelease.version}" || exit 2
 git -C build/website/ push || exit 3
 ./gradlew shadowJar --parallel || ./gradlew shadowJar --parallel || exit 4
-./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform release --parallel || ./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform release --parallel exit 5
+RELEASE_ON_CENTRAL="./gradlew uploadKotlinOSSRH uploadKotlinMultiplatform uploadJvm uploadJs release --parallel"
+eval "$RELEASE_ON_CENTRAL" || eval "$RELEASE_ON_CENTRAL" || eval "$RELEASE_ON_CENTRAL" || exit 5
 ./gradlew publishKotlinOSSRHPublicationToGithubRepository --continue || true
 `
 var config = require('semantic-release-preconfigured-conventional-commits');


### PR DESCRIPTION
I believe we forgot to integrate the changes in dce26ef917173277dd6c588713e94954bc6f3b41.
With this PR the correct artifacts should be correctly uploaded for Multiplatform project on releases.