### PR TITLE
fix(web-renderer): solve coroutine bug caused by useEffect and serialization problem in "/simulation/status" API

### DIFF
--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/AppContent.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/client/components/AppContent.kt
@@ -16,32 +16,35 @@ import it.unibo.alchemist.client.logic.RESTUpdateStateStrategy
 import it.unibo.alchemist.client.logic.updateState
 import it.unibo.alchemist.client.state.ClientStore.store
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import react.FC
 import react.Props
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.img
+import react.useEffectOnce
 import react.useState
-import web.timers.setInterval
-import kotlin.time.Duration
 
 private val scope = MainScope()
+private const val UPDATE_STATE_DELAY: Long = 100
 
 /**
  * The application main content section.
  */
 val AppContent: FC<Props> = FC {
 
-    val intervalDuration = "5s"
     var bitmap: Bitmap? by useState(null)
 
     store.subscribe {
         bitmap = store.state.bitmap
     }
 
-    setInterval(Duration.parse(intervalDuration)) {
+    useEffectOnce {
         scope.launch {
-            updateState(store.state.renderMode, RESTUpdateStateStrategy(), HwAutoRenderModeStrategy())
+            while (true) {
+                updateState(store.state.renderMode, RESTUpdateStateStrategy(), HwAutoRenderModeStrategy())
+                delay(UPDATE_STATE_DELAY)
+            }
         }
     }
 

--- a/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
+++ b/alchemist-web-renderer/src/jvmMain/kotlin/it/unibo/alchemist/server/routes/SimulationRoute.kt
@@ -41,11 +41,9 @@ object SimulationRoute {
      */
     fun Route.simulationStatus() {
         get(simulationStatusPath) {
-            respond(
-                store.state.simulation?.status?.let { status ->
-                    Response(OK, status.toStatusSurrogate())
-                } ?: Response(InternalServerError, "Simulation not loaded.")
-            )
+            store.state.simulation?.status?.toStatusSurrogate()?.let { status ->
+                respond(Response(OK, status))
+            } ?: respond(Response(InternalServerError, "Simulation not loaded."))
         }
     }
 


### PR DESCRIPTION
This PR solves two bugs in the `alchemist-web-renderer` subproject:

1. `updateState` is now called inside `useEffectOnce`. By doing this the body of `useEffectOnce` is executed only one time (during the initialization phase of the component) instead of every time the component is rendered.
2. The serialization of `StatusSurrogate` always works now when using the `/simulation/status` API.