### PR TITLE
fix(web-renderer): solve props bug introduced in pre.609

### DIFF
--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/buttons/Button.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/buttons/Button.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.buttons
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap Button adapter.
@@ -27,7 +27,7 @@ external val Button: ComponentClass<ButtonProps>
 /**
  * Props used to customize the Button.
  */
-external interface ButtonProps : Props {
+external interface ButtonProps : PropsWithChildren {
 
     /**
      * active prop, false by default.

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/buttons/ToggleButton.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/buttons/ToggleButton.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.buttons
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap ToggleButton adapter.
@@ -27,7 +27,7 @@ external val ToggleButton: ComponentClass<ToggleButtonProps>
 /**
  * Props used to customize the ToggleButton.
  */
-external interface ToggleButtonProps : Props {
+external interface ToggleButtonProps : PropsWithChildren {
 
     /**
      * id props, required.

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/buttons/ToggleButtonGroup.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/buttons/ToggleButtonGroup.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.buttons
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap ToggleButtonGroup adapter.
@@ -27,7 +27,7 @@ external val ToggleButtonGroup: ComponentClass<ToggleButtonGroupProps>
 /**
  * Props used to customize the ToggleButtonGroup.
  */
-external interface ToggleButtonGroupProps : Props {
+external interface ToggleButtonGroupProps : PropsWithChildren {
     /**
      * type prop, 'checkbox' | 'radio'.
      */

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/Modal.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/Modal.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.modal
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap Modal adapter.
@@ -27,7 +27,7 @@ external val Modal: ComponentClass<ModalProps>
 /**
  * Props used to customize the Modal.
  */
-external interface ModalProps : Props {
+external interface ModalProps : PropsWithChildren {
     /**
      * show prop, false by default.
      */

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalBody.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalBody.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.modal
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap ModalBody adapter.
@@ -22,4 +22,4 @@ import react.Props
  */
 
 @JsName("default")
-external val ModalBody: ComponentClass<Props>
+external val ModalBody: ComponentClass<PropsWithChildren>

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalFooter.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalFooter.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.modal
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap ModalFooter adapter.
@@ -22,4 +22,4 @@ import react.Props
  */
 
 @JsName("default")
-external val ModalFooter: ComponentClass<Props>
+external val ModalFooter: ComponentClass<PropsWithChildren>

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalHeader.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalHeader.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.modal
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap ModalHeader adapter.
@@ -27,7 +27,7 @@ external val ModalHeader: ComponentClass<ModalHeaderProps>
 /**
  * Props used to customize the ModalHeader.
  */
-external interface ModalHeaderProps : Props {
+external interface ModalHeaderProps : PropsWithChildren {
     /**
      * closeButton prop.
      */

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalTitle.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/modal/ModalTitle.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.modal
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap ModalTitle adapter.
@@ -27,7 +27,7 @@ external val ModalTitle: ComponentClass<ModalTitleProps>
 /**
  * Props used to customize the ModalHeader.
  */
-external interface ModalTitleProps : Props {
+external interface ModalTitleProps : PropsWithChildren {
     /**
      * className prop. Useful for customizing.
      */

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/navbar/Navbar.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/navbar/Navbar.kt
@@ -13,7 +13,7 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.navbar
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * React Bootstrap Navbar adapter.
@@ -25,7 +25,7 @@ external val Navbar: ComponentClass<NavbarProps>
 /**
  * Props used to customize the Navbar.
  */
-external interface NavbarProps : Props {
+external interface NavbarProps : PropsWithChildren {
     /**
      * bg props.
      */

--- a/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/navbar/Navbar.ktx.kt
+++ b/alchemist-web-renderer/src/jsMain/kotlin/it/unibo/alchemist/boundary/webui/client/adapters/reactBootstrap/navbar/Navbar.ktx.kt
@@ -10,11 +10,11 @@
 package it.unibo.alchemist.boundary.webui.client.adapters.reactBootstrap.navbar
 
 import react.ComponentClass
-import react.Props
+import react.PropsWithChildren
 
 /**
  * Navbar.Brand component.
  * Note: an explicit cast is required here, as the original Javascript structure is dynamic.
  */
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-val NavbarBrand: ComponentClass<Props> = Navbar.asDynamic().Brand as ComponentClass<Props>
+val NavbarBrand: ComponentClass<PropsWithChildren> = Navbar.asDynamic().Brand as ComponentClass<PropsWithChildren>


### PR DESCRIPTION
This wasn't an easy one. Seems like `pre.609` changed the way the `Props` interface work (in a better way imo). Using the correct new interface `PropsWithChildren`  seems to work now.  There's a [closed issue](https://github.com/JetBrains/kotlin-wrappers/issues/2095#issuecomment-1686373143) in kotlin wrappers where the same problem (more or less, the scenario is different) is presented. I also added a comment explaining my situation and I am waiting for a reply, to improve even more the solution if possible. However, I think that I have an enough good level of knowledge of how React works to say that this solution seems to be the best. 