### PR TITLE
build!(graphql): switch to Java 17

### DIFF
--- a/alchemist-graphql/build.gradle.kts
+++ b/alchemist-graphql/build.gradle.kts
@@ -139,8 +139,8 @@ publishing.publications {
         pom {
             contributors {
                 contributor {
-                    name.set("Angelo Filaseta")
-                    email.set("angelo.filaseta@studio.unibo.it")
+                    name.set("Stefano Furi")
+                    email.set("stefano.furi@studio.unibo.it")
                 }
             }
         }

--- a/alchemist-graphql/build.gradle.kts
+++ b/alchemist-graphql/build.gradle.kts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+import Libs.alchemist
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateSDLTask
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+plugins {
+    application
+    alias(libs.plugins.kotest.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ktor)
+    alias(libs.plugins.graphql.server)
+}
+
+dependencies {
+    implementation("io.ktor:ktor-server-cors-jvm:2.3.3")
+    implementation("io.ktor:ktor-server-core-jvm:2.3.3")
+    implementation("io.ktor:ktor-server-websockets-jvm:2.3.3")
+}
+
+kotlin {
+    jvm {
+        withJava()
+
+        // workaround for fixing "task compileKotlin not found", will be fixed in GraphQL Kotlin v.7
+        tasks.maybeCreate("compileKotlin").dependsOn(tasks.named("compileKotlinJvm"))
+        tasks.named<GraphQLGenerateSDLTask>("graphqlGenerateSDL") {
+            val srcSet = sourceSets.getByName("jvmMain").kotlin
+            source = srcSet.asFileTree
+            projectClasspath.setFrom(srcSet)
+        }
+        tasks {
+            graphql {
+                schema {
+                    packages = listOf(
+                        "it.unibo.alchemist.boundary.graphql",
+                    )
+                }
+            }
+
+            // Disabling GraphQL Kotlin unwanted tasks
+            listOf(
+                "graphqlGenerateClient",
+                "graphqlGenerateTestClient",
+            ).map {
+                this.getByName(it)
+            }.forEach { it.enabled = false }
+        }
+    }
+
+    js(IR) {
+        browser {
+            binaries.executable()
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.kotlinx.serialization.json)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+                api(alchemist("api"))
+                implementation(rootProject)
+                implementation(libs.bundles.graphql.server)
+                implementation(libs.bundles.ktor.server)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.kotest.assertions)
+                implementation(libs.kotest.runner)
+                implementation(libs.ktor.server.test.host)
+                implementation(alchemist("euclidean-geometry"))
+                implementation(alchemist("implementationbase"))
+                implementation(alchemist("test"))
+            }
+        }
+        val jsMain by getting {
+            dependencies {
+                implementation(libs.apollo.runtime)
+                implementation(libs.kotlin.coroutines.core)
+            }
+        }
+        val jsTest by getting
+    }
+}
+
+application {
+    mainClass.set("it.unibo.alchemist.Alchemist")
+}
+
+/**
+ * Webpack task that generates the JS artifacts.
+ */
+val webpackTask = tasks.named("jsBrowserProductionWebpack")
+
+tasks.named("run", JavaExec::class).configure {
+    classpath(
+        tasks.named("compileKotlinJvm"),
+        configurations.named("jvmRuntimeClasspath"),
+        webpackTask.map { task ->
+            task.outputs.files.map { file ->
+                file.parent
+            }
+        },
+    )
+}
+
+/**
+ * Configure the [ShadowJar] task to work exactly like the "jvmJar" task of Kotlin Multiplatform, but also
+ * include the JS artifacts by depending on the "jsBrowserProductionWebpack" task.
+ */
+tasks.withType<ShadowJar>().configureEach {
+    val jvmJarTask = tasks.named("jvmJar")
+    from(webpackTask)
+    from(jvmJarTask)
+    from(tasks.named("jsBrowserDistribution"))
+    mustRunAfter(tasks.distTar, tasks.distZip)
+    archiveClassifier.set("all")
+}
+
+publishing.publications {
+    withType<MavenPublication> {
+        pom {
+            contributors {
+                contributor {
+                    name.set("Angelo Filaseta")
+                    email.set("angelo.filaseta@studio.unibo.it")
+                }
+            }
+        }
+    }
+}

--- a/alchemist-graphql/gradle.properties
+++ b/alchemist-graphql/gradle.properties
@@ -10,7 +10,7 @@
 group = it.unibo.alchemist
 artifactId = alchemist-graphql
 projectLongName = Alchemist GraphQL
-projectDescription = Alchemist module that provides GraphQL APIs for simulations
+projectDescription = GraphQL API for Alchemist 
 
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true

--- a/alchemist-graphql/gradle.properties
+++ b/alchemist-graphql/gradle.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2010-2023, Danilo Pianini and contributors
+# listed, for each module, in the respective subproject's build.gradle.kts file.
+#
+# This file is part of Alchemist, and is distributed under the terms of the
+# GNU General Public License, with a linking exception,
+# as described in the file LICENSE in the Alchemist distribution's top directory.
+#
+
+group = it.unibo.alchemist
+artifactId = alchemist-graphql
+projectLongName = Alchemist GraphQL
+projectDescription = Alchemist module that provides GraphQL APIs for simulations
+
+kotlin.code.style=official
+kotlin.mpp.stability.nowarn=true

--- a/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/TestQuery.kt
+++ b/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/TestQuery.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.boundary.graphql.schema.operations
+
+import com.expediagroup.graphql.server.operations.Query
+
+/**
+ * A GraphQL test query.
+ * This is used to test the GraphQL module.
+ * Once domain specific queries are implemented, this class will be removed.
+ */
+class TestQuery : Query {
+    /**
+     * A test query that return today date in ms.
+     */
+    fun today() = "Today is ${System.currentTimeMillis()}"
+}

--- a/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/graphql/server/modules/GraphQLModule.kt
+++ b/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/graphql/server/modules/GraphQLModule.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.boundary.graphql.server.modules
+
+import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
+import com.expediagroup.graphql.server.ktor.DefaultKtorGraphQLContextFactory
+import com.expediagroup.graphql.server.ktor.GraphQL
+import io.ktor.serialization.jackson.JacksonWebsocketContentConverter
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.compression.Compression
+import io.ktor.server.plugins.compression.gzip
+import io.ktor.server.plugins.cors.routing.CORS
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.pingPeriod
+import io.ktor.server.websocket.timeout
+import it.unibo.alchemist.boundary.graphql.schema.operations.TestQuery
+import java.time.Duration
+
+// The following values are referred to milliseconds.
+private const val DEFAULT_PING_PERIOD = 1000L
+private const val DEFAULT_TIMEOUT_DURATION = 10000L
+
+/**
+ * Ktor module for enabling GraphQL on server.
+ */
+fun Application.graphQLModule() {
+    install(CORS) {
+        anyHost()
+    }
+
+    install(Compression) {
+        gzip()
+    }
+
+    install(WebSockets) {
+        pingPeriod = Duration.ofMillis(DEFAULT_PING_PERIOD)
+        timeout = Duration.ofMillis(DEFAULT_TIMEOUT_DURATION)
+        maxFrameSize = Long.MAX_VALUE
+        masking = false
+        contentConverter = JacksonWebsocketContentConverter()
+    }
+
+    install(GraphQL) {
+        schema {
+            packages = listOf(
+                "it.unibo.alchemist.boundary.graphql.schema",
+            )
+            // An error is raised if no queries are provided.
+            // When queries will be ready, this will be removed.
+            queries = listOf(TestQuery())
+            mutations = emptyList()
+            subscriptions = emptyList()
+            hooks = FlowSubscriptionSchemaGeneratorHooks()
+        }
+
+        server {
+            contextFactory = DefaultKtorGraphQLContextFactory()
+        }
+    }
+}

--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -133,15 +133,3 @@ publishing.publications {
         }
     }
 }
-
-/*
- * This is a workaround for the following Gradle error,
- * and should be removed as soon as possible.
- *
- * * What went wrong:
- * Execution failed for task ':dokkaHtmlCollector'.
- * > Could not determine the dependencies of null.
- * > Current thread does not hold the state lock for project ':alchemist-web-renderer'
- */
-val dokkaHtmlCollector by rootProject.tasks.named("dokkaHtmlCollector")
-dokkaHtmlCollector.dependsOn(tasks.dokkaHtml)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -391,18 +391,16 @@ tasks {
         outputDirectory = websiteDir
     }
 
-// Exclude the UI packages from the collector documentation.
+// Exclude the UI and Multiplatform packages from the collector documentation.
     withType<DokkaCollectorTask>().configureEach {
         /*
          * Although the method is deprecated, no valid alternative has been implemented yet.
          * Disabling individual partial tasks has been proven ineffective.
          */
         removeChildTasks(
-            listOf(
+            allprojects.filter { it.isMultiplatform } + listOf(
                 alchemist("fxui"),
                 alchemist("swingui"),
-                alchemist("web-renderer"),
-                alchemist("graphql"),
             ),
         )
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ allprojects {
     apply(plugin = "distribution")
 
     multiJvm {
-        jvmVersionForCompilation.set(11)
+        jvmVersionForCompilation.set(17)
         maximumSupportedJvmVersion.set(latestJava)
         if (isInCI && (isWindows || isMac)) {
             /*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,6 +162,17 @@ allprojects {
                 }
             }
         }
+        /*
+         * This is a workaround for the following Gradle error,
+         * and should be removed as soon as possible.
+         *
+         * * What went wrong:
+         * Execution failed for task ':dokkaHtmlCollector'.
+         * > Could not determine the dependencies of null.
+         * > Current thread does not hold the state lock for project ':alchemist-web-renderer'
+         */
+        val dokkaHtmlCollector by rootProject.tasks.named("dokkaHtmlCollector")
+        dokkaHtmlCollector.dependsOn(tasks.dokkaHtml)
     }
 
     // COMPILE
@@ -391,6 +402,7 @@ tasks {
                 alchemist("fxui"),
                 alchemist("swingui"),
                 alchemist("web-renderer"),
+                alchemist("graphql"),
             ),
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 antlr4 = "4.13.1"
+apollo ="4.0.0-alpha.2"
 arrow = "1.2.1"
 graphhopper = "7.0"
 graphql-server = "6.5.3"
@@ -28,6 +29,7 @@ apache-commons-collections4 = "org.apache.commons:commons-collections4:4.4"
 apache-commons-io = "commons-io:commons-io:2.13.0"
 apache-commons-lang3 = "org.apache.commons:commons-lang3:3.13.0"
 apache-commons-math3 = "org.apache.commons:commons-math3:3.6.1"
+apollo-runtime = { module = "com.apollographql.apollo3:apollo-runtime", version.ref = "apollo" }
 appdirs = "net.harawata:appdirs:1.2.2"
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 boilerplate = "org.danilopianini:boilerplate:0.2.2"
@@ -151,6 +153,7 @@ testing-runtimeOnly = [ "junit-engine" ]
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gitSemVer = "org.danilopianini.git-sensitive-semantic-versioning-gradle-plugin:1.1.10"
+graphql-client = { id = "com.apollographql.apollo3", version.ref = "apollo" }
 graphql-server = { id = "com.expediagroup.graphql", version.ref = "graphql-server" }
 hugo = "io.github.fstaudt.hugo:0.6.1"
 java-qa = "org.danilopianini.gradle-java-qa:1.17.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,8 @@
 antlr4 = "4.13.1"
 arrow = "1.2.1"
 graphhopper = "7.0"
+graphql-server = "6.5.3"
+graphql-server-ktor = "7.0.0-alpha.6"
 graphstream = "2.0"
 ignite = "2.15.0"
 junit = "5.10.0"
@@ -37,6 +39,8 @@ dyn4j = "org.dyn4j:dyn4j:5.0.1"
 dsiutils = "it.unimi.dsi:dsiutils:2.7.3"
 embedmongo = "de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.9.2"
 graphhopper-core = { module = "com.graphhopper:graphhopper-core", version.ref = "graphhopper" }
+graphql-server = { module = "com.expediagroup:graphql-kotlin-server", version.ref = "graphql-server" }
+graphql-server-ktor = { module = "com.expediagroup:graphql-kotlin-ktor-server", version.ref = "graphql-server-ktor" }
 graphstream-algo = { module = "org.graphstream:gs-algo", version.ref = "graphstream" }
 graphstream-core = { module = "org.graphstream:gs-core", version.ref = "graphstream" }
 groovy-jsr223 = "org.codehaus.groovy:groovy-jsr223:3.0.19"
@@ -77,6 +81,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-serialization", version.ref = "ktor" }
+ktor-serialization-jackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-compression = { module = "io.ktor:ktor-server-compression", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
@@ -84,6 +89,7 @@ ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
 ktor-server-core-jvm = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets-jvm", version.ref = "ktor" }
 leafletmap = "org.danilopianini:de.saring.leafletmap:1.0.5"
 listset = "org.danilopianini:listset:0.3.9"
 logback = "ch.qos.logback:logback-classic:1.4.11"
@@ -115,17 +121,20 @@ trove4j = "net.sf.trove4j:trove4j:3.0.3"
 
 [bundles]
 graphhopper = [ "graphhopper-core" ]
+graphql-server = [ "graphql-server", "graphql-server-ktor" ]
 jiconfont = [ "jiconfont-javafx", "jiconfont-materialDesignIcons" ]
 kotlin-react = [ "kotlin-react", "kotlin-react-dom" ]
 ktor-client = [ "ktor-client-js", "ktor-client-content-negotiation", "ktor-serialization-kotlinx-json" ]
 ktor-server = [
     "ktor-serialization",
+    "ktor-serialization-jackson",
     "ktor-serialization-kotlinx-json",
     "ktor-server-compression",
     "ktor-server-content-negotiation",
     "ktor-server-cors",
     "ktor-server-core-jvm",
-    "ktor-server-netty"
+    "ktor-server-netty",
+    "ktor-server-websockets"
 ]
 protelis = [ "protelis-interpreter", "protelis-lang" ]
 scala = [ "scala-compiler", "scala-library" ]
@@ -142,6 +151,7 @@ testing-runtimeOnly = [ "junit-engine" ]
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gitSemVer = "org.danilopianini.git-sensitive-semantic-versioning-gradle-plugin:1.1.10"
+graphql-server = { id = "com.expediagroup.graphql", version.ref = "graphql-server" }
 hugo = "io.github.fstaudt.hugo:0.6.1"
 java-qa = "org.danilopianini.gradle-java-qa:1.17.0"
 kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotest" }
@@ -149,6 +159,7 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-qa = "org.danilopianini.gradle-kotlin-qa:0.49.1"
+ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 multiJvmTesting = "org.danilopianini.multi-jvm-test-plugin:0.5.5"
 publishOnCentral = "org.danilopianini.publish-on-central:5.0.13"
 scalafmt = "cz.alenkacz.gradle.scalafmt:1.16.2"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include(
     "alchemist-engine",
     "alchemist-euclidean-geometry",
     "alchemist-full",
+    "alchemist-graphql",
     "alchemist-grid",
     "alchemist-implementationbase",
     "alchemist-incarnation-protelis",


### PR DESCRIPTION
Add GraphQL module dependencies and basic build configuration file.
`GraphQLModule` has been added because `isMultiplatfrom` build check requires at least one multiplatform sourceset to be available. 