### PR TITLE
docs(website): use https URIs over ssh ones for the tutorial

### DIFF
--- a/site/content/tutorials/basics/_index.md
+++ b/site/content/tutorials/basics/_index.md
@@ -42,7 +42,7 @@ If you have no idea of what I'm talking about,
 [take a step back and make sure you followed the quickstart](../quickstart).
 {{% /notice %}}
 
-1. `git clone git@github.com:DanySK/DisCoTec-2021-Tutorial.git`
+1. `git clone https://github.com/DanySK/DisCoTec-2021-Tutorial.git`
 2. `cd DisCoTec-2021-Tutorial`
 3.
     * Unix-like terminals: `./gradlew run00`


### PR DESCRIPTION
Change not working git ssh link to https link.
![image](https://github.com/AlchemistSimulator/Alchemist/assets/55553082/278a6619-07ee-48df-ae10-eb759cd7a99d)
