### PR TITLE
fix(ui-tooling): adjust the initial GUI centering on the map

### DIFF
--- a/alchemist-ui-tooling/src/main/java/it/unibo/alchemist/boundary/ui/impl/AbstractWormhole2D.java
+++ b/alchemist-ui-tooling/src/main/java/it/unibo/alchemist/boundary/ui/impl/AbstractWormhole2D.java
@@ -249,7 +249,7 @@ public abstract class AbstractWormhole2D<P extends Position2D<? extends P>> impl
         final double[] size = getEnvironment().getSize();
         final PointAdapter<P> center = Double.isNaN(off[0]) || Double.isNaN(off[1]) || size[0] <= 0 || size[1] <= 0
                 ? from(0, 0)
-                : from(-(off[0] + size[0] / 2), -(off[1] + size[1] / 2));
+                : from((off[0] + size[0] / 2), (off[1] + size[1] / 2));
         setEnvPosition(center.toPosition(environment));
     }
 

--- a/alchemist-ui-tooling/src/main/java/it/unibo/alchemist/boundary/ui/impl/AbstractWormhole2D.java
+++ b/alchemist-ui-tooling/src/main/java/it/unibo/alchemist/boundary/ui/impl/AbstractWormhole2D.java
@@ -249,7 +249,7 @@ public abstract class AbstractWormhole2D<P extends Position2D<? extends P>> impl
         final double[] size = getEnvironment().getSize();
         final PointAdapter<P> center = Double.isNaN(off[0]) || Double.isNaN(off[1]) || size[0] <= 0 || size[1] <= 0
                 ? from(0, 0)
-                : from((off[0] + size[0] / 2), (off[1] + size[1] / 2));
+                : from(off[0] + size[0] / 2, off[1] + size[1] / 2);
         setEnvPosition(center.toPosition(environment));
     }
 


### PR DESCRIPTION
Fix the error when the points on the map were not zoomed properly on simulation start.
Before fix: 
![Screenshot 2023-11-10 172014](https://github.com/AlchemistSimulator/Alchemist/assets/55553082/46db88c8-a07d-40e3-a617-064a6f3e09d9)
After fix:
![Screenshot 2023-11-10 172152](https://github.com/AlchemistSimulator/Alchemist/assets/55553082/5824ca30-fb69-41ee-994e-2c4ba134345c)
