### PR TITLE
fix!: overloads constructor and change the order of constructor parameters to specify only the variables parameter

### DIFF
--- a/alchemist-loading/src/main/kotlin/it/unibo/alchemist/boundary/launchers/HeadlessSimulationLauncher.kt
+++ b/alchemist-loading/src/main/kotlin/it/unibo/alchemist/boundary/launchers/HeadlessSimulationLauncher.kt
@@ -18,9 +18,9 @@ import java.util.concurrent.TimeUnit
 /**
  * Executes simulations locally in a headless environment.
  */
-class HeadlessSimulationLauncher(
-    private val parallelism: Int = defaultParallelism,
+class HeadlessSimulationLauncher @JvmOverloads constructor(
     private val variables: List<String> = emptyList(),
+    private val parallelism: Int = defaultParallelism,
 ) : SimulationLauncher() {
 
     private val logger = LoggerFactory.getLogger(this::class.java)


### PR DESCRIPTION
This PR changes the way `HeadlessSimulationLauncher` can be used in conjunction with the CLI of the simulator.

Previously, since the `@JvmOverload` annotation was missing, the only way to instantiate the class was via the 2-arguments constructor.
When a batch is required, the only way to instantiate the class requires specifying both `parallelism` and `variables`,
resulting in a hard-coded value for the `parallelism` value.

With the change introduced in this PR, now only the `variables` parameters can be specified, defaulting the `parallelism` to the number of cores of the running machine.