### PR TITLE
fix: conflicts between gradle plugins and imports in multiplatform projects

### DIFF
--- a/alchemist-graphql/build.gradle.kts
+++ b/alchemist-graphql/build.gradle.kts
@@ -16,10 +16,8 @@ import io.gitlab.arturbosch.detekt.Detekt
 import java.io.File.separator
 
 plugins {
-    application
     alias(libs.plugins.kotest.multiplatform)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ktor)
     alias(libs.plugins.graphql.server)
     alias(libs.plugins.graphql.client)
 }
@@ -68,10 +66,6 @@ kotlin {
             }
         }
     }
-}
-
-application {
-    mainClass.set("it.unibo.alchemist.Alchemist")
 }
 
 graphql {
@@ -126,18 +120,6 @@ tasks.withType<ApolloGenerateSourcesTask>().configureEach {
  * Webpack task that generates the JS artifacts.
  */
 val webpackTask = tasks.named("jsBrowserProductionWebpack")
-
-tasks.named("run", JavaExec::class).configure {
-    classpath(
-        tasks.named("compileKotlinJvm"),
-        configurations.named("jvmRuntimeClasspath"),
-        webpackTask.map { task ->
-            task.outputs.files.map { file ->
-                file.parent
-            }
-        },
-    )
-}
 
 /**
  * Configure the [ShadowJar] task to work exactly like the "jvmJar" task of Kotlin Multiplatform, but also

--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -12,7 +12,6 @@ import Libs.incarnation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    application
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotest.multiplatform)
 }
@@ -87,26 +86,10 @@ kotlin {
     }
 }
 
-application {
-    mainClass.set("it.unibo.alchemist.Alchemist")
-}
-
 /**
  * Webpack task that generates the JS artifacts.
  */
 val webpackTask = tasks.named("jsBrowserProductionWebpack")
-
-tasks.named("run", JavaExec::class).configure {
-    classpath(
-        tasks.named("compileKotlinJvm"),
-        configurations.named("jvmRuntimeClasspath"),
-        webpackTask.map { task ->
-            task.outputs.files.map { file ->
-                file.parent
-            }
-        },
-    )
-}
 
 /**
  * Configure the [ShadowJar] task to work exactly like the "jvmJar" task of Kotlin Multiplatform, but also

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,34 +44,22 @@ plugins {
 val minJavaVersion: String by properties
 
 allprojects {
-
     with(rootProject.libs.plugins) {
         if (project.isMultiplatform) {
             apply(plugin = kotlin.multiplatform.id)
         } else {
             apply(plugin = kotlin.jvm.id)
+            apply(plugin = multiJvmTesting.id)
+            apply(plugin = java.qa.id)
         }
         apply(plugin = dokka.id)
         apply(plugin = gitSemVer.id)
-        apply(plugin = java.qa.id)
-        apply(plugin = multiJvmTesting.id)
         apply(plugin = kotlin.qa.id)
         apply(plugin = publishOnCentral.id)
         apply(plugin = shadowJar.id)
         apply(plugin = taskTree.id)
     }
     apply(plugin = "distribution")
-
-    multiJvm {
-        jvmVersionForCompilation.set(minJavaVersion.toInt())
-        maximumSupportedJvmVersion.set(latestJava)
-        if (isInCI && (isWindows || isMac)) {
-            /*
-             * Reduce time in CI by running on fewer JVMs on slower or more limited instances.
-             */
-            testByDefaultWith(latestJava)
-        }
-    }
 
     repositories {
         google()
@@ -86,8 +74,70 @@ allprojects {
     }
 
     // JVM PROJECTS CONFIGURATIONS
-
     if (!project.isMultiplatform) {
+        // CODE QUALITY
+
+        javaQA {
+            checkstyle {
+                additionalConfiguration.set(
+                    """
+                    <module name="RegexpSingleline">
+                        <property name="severity" value="error" />
+                        <property name="format" value="Math\s*\.\s*random\s*\(\s*\)" />
+                        <property name="fileExtensions" value="java,xtend,scala,kt" />
+                        <property name="message"
+                                  value="Don't use Math.random() inside Alchemist. Breaks stuff." />
+                    </module>
+                    <module name="RegexpSingleline">
+                        <property name="severity" value="error" />
+                        <property name="format" value="class\s*\.\s*forName\s*\(" />
+                        <property name="fileExtensions" value="java,xtend,scala,kt" />
+                        <property name="message"
+                                  value="Use the library to load classes and resources. Breaks grid otherwise." />
+                    </module>
+                    <module name="RegexpSingleline">
+                        <property name="severity" value="error" />
+                        <property name="format" value="class\s*\.\s*getResource" />
+                        <property name="fileExtensions" value="java,xtend,scala,kt" />
+                        <property name="message"
+                                  value="Use the library to load classes and resources. Breaks grid otherwise." />
+                    </module>
+                    <module name="RegexpSingleline">
+                        <property name="severity" value="error" />
+                        <property name="format" value="class\s*\.\s*getClassLoader" />
+                        <property name="fileExtensions" value="java,xtend,scala,kt" />
+                        <property name="message"
+                                  value="Use the library to load classes and resources. Breaks grid otherwise." />
+                    </module>
+                    <module name="RegexpSingleline">
+                        <property name="severity" value="warning" />
+                        <property name="format" value="@author" />
+                        <property name="fileExtensions" value="java,xtend,scala,kt" />
+                        <property name="message"
+                                  value="Do not use @author. Changes and authors are tracked by the content manager." />
+                    </module>
+                    """.trimIndent(),
+                )
+                additionalSuppressions.set(
+                    """
+                    <suppress files=".*[\\/]expressions[\\/]parser[\\/].*" checks=".*"/>
+                    <suppress files=".*[\\/]biochemistrydsl[\\/].*" checks=".*"/>
+                    """.trimIndent(),
+                )
+            }
+        }
+
+        multiJvm {
+            jvmVersionForCompilation.set(minJavaVersion.toInt())
+            maximumSupportedJvmVersion.set(latestJava)
+            if (isInCI && (isWindows || isMac)) {
+                /*
+                 * Reduce time in CI by running on fewer JVMs on slower or more limited instances.
+                 */
+                testByDefaultWith(latestJava)
+            }
+        }
+
         dependencies {
             with(rootProject.libs) {
                 compileOnly(spotbugs.annotations)
@@ -202,58 +252,6 @@ allprojects {
         }
         useJUnitPlatform()
         maxHeapSize = "1g"
-    }
-
-    // CODE QUALITY
-
-    javaQA {
-        checkstyle {
-            additionalConfiguration.set(
-                """
-                <module name="RegexpSingleline">
-                    <property name="severity" value="error" />
-                    <property name="format" value="Math\s*\.\s*random\s*\(\s*\)" />
-                    <property name="fileExtensions" value="java,xtend,scala,kt" />
-                    <property name="message"
-                              value="Don't use Math.random() inside Alchemist. Breaks stuff." />
-                </module>
-                <module name="RegexpSingleline">
-                    <property name="severity" value="error" />
-                    <property name="format" value="class\s*\.\s*forName\s*\(" />
-                    <property name="fileExtensions" value="java,xtend,scala,kt" />
-                    <property name="message"
-                              value="Use the library to load classes and resources. Breaks grid otherwise." />
-                </module>
-                <module name="RegexpSingleline">
-                    <property name="severity" value="error" />
-                    <property name="format" value="class\s*\.\s*getResource" />
-                    <property name="fileExtensions" value="java,xtend,scala,kt" />
-                    <property name="message"
-                              value="Use the library to load classes and resources. Breaks grid otherwise." />
-                </module>
-                <module name="RegexpSingleline">
-                    <property name="severity" value="error" />
-                    <property name="format" value="class\s*\.\s*getClassLoader" />
-                    <property name="fileExtensions" value="java,xtend,scala,kt" />
-                    <property name="message"
-                              value="Use the library to load classes and resources. Breaks grid otherwise." />
-                </module>
-                <module name="RegexpSingleline">
-                    <property name="severity" value="warning" />
-                    <property name="format" value="@author" />
-                    <property name="fileExtensions" value="java,xtend,scala,kt" />
-                    <property name="message"
-                              value="Do not use @author. Changes and authors are tracked by the content manager." />
-                </module>
-                """.trimIndent(),
-            )
-            additionalSuppressions.set(
-                """
-                <suppress files=".*[\\/]expressions[\\/]parser[\\/].*" checks=".*"/>
-                <suppress files=".*[\\/]biochemistrydsl[\\/].*" checks=".*"/>
-                """.trimIndent(),
-            )
-        }
     }
 
     tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -164,7 +164,6 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-qa = "org.danilopianini.gradle-kotlin-qa:0.59.0"
-ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 multiJvmTesting = "org.danilopianini.multi-jvm-test-plugin:0.5.5"
 publishOnCentral = "org.danilopianini.publish-on-central:5.0.22"
 scalafmt = "cz.alenkacz.gradle.scalafmt:1.16.2"


### PR DESCRIPTION
This PR should resolve the problem described in issue #3071
It seems like some plugins interfere with the import of classes between multiplatform projects.

Such plugins are:
- `application`
- `ktor` plugin
- `multi-jvm-test`
- `javaQA`

As a solution, I removed the application and ktor plugins from some MP projects. The others are still applied to JVM-only projects. If further investigation is required, I could make an attempt.