### PR TITLE
feat(graphql)!: add SimulationSurrogate and more support to subscriptions

### DIFF
--- a/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/model/surrogates/EnvironmentSurrogate.kt
+++ b/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/model/surrogates/EnvironmentSurrogate.kt
@@ -18,6 +18,7 @@ import it.unibo.alchemist.model.Layer
 import it.unibo.alchemist.model.Molecule
 import it.unibo.alchemist.model.Position
 import it.unibo.alchemist.model.times.DoubleTime
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Semaphore
 import kotlin.jvm.optionals.getOrNull
 

--- a/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/model/surrogates/EnvironmentSurrogate.kt
+++ b/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/model/surrogates/EnvironmentSurrogate.kt
@@ -18,7 +18,6 @@ import it.unibo.alchemist.model.Layer
 import it.unibo.alchemist.model.Molecule
 import it.unibo.alchemist.model.Position
 import it.unibo.alchemist.model.times.DoubleTime
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Semaphore
 import kotlin.jvm.optionals.getOrNull
 

--- a/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/model/surrogates/SimulationSurrogate.kt
+++ b/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/model/surrogates/SimulationSurrogate.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2010-2024, Danilo Pianini and contributors
+ * listed, for each module, in the respective subproject's build.gradle.kts file.
+ *
+ * This file is part of Alchemist, and is distributed under the terms of the
+ * GNU General Public License, with a linking exception,
+ * as described in the file LICENSE in the Alchemist distribution's top directory.
+ */
+
+package it.unibo.alchemist.boundary.graphql.schema.model.surrogates
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
+import it.unibo.alchemist.core.Simulation
+import it.unibo.alchemist.model.Position
+
+/**
+ * A surrogate for [Simulation].
+ * @param T the concentration type
+ * @param P the position
+ */
+@GraphQLDescription("The simulation")
+data class SimulationSurrogate<T, P : Position<out P>>(
+    @GraphQLIgnore override val origin: Simulation<T, P>,
+) : GraphQLSurrogate<Simulation<T, P>>(origin) {
+
+    /**
+     * The time of the simulation.
+     */
+    @GraphQLDescription("The status of the simulation")
+    fun status(): String = origin.status.toString()
+
+    /**
+     * The time of the simulation.
+     */
+    @GraphQLDescription("The time of the simulation")
+    fun time(): Double = origin.time.toDouble()
+
+    /**
+     * The environment of the simulation.
+     */
+    @GraphQLDescription("The environment of the simulation")
+    fun environment(): EnvironmentSurrogate<T, P> = origin.environment.toGraphQLEnvironmentSurrogate()
+}
+
+/**
+ * Converts a [Simulation] to a [SimulationSurrogate].
+ * @param T the concentration type
+ * @param P the position
+ * @return a [SimulationSurrogate] representing the given [Simulation]
+ */
+fun <T, P : Position<out P>> Simulation<T, P>.toGraphQLSimulationSurrogate() = SimulationSurrogate(this)

--- a/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/queries/EnvironmentQueries.kt
+++ b/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/queries/EnvironmentQueries.kt
@@ -12,6 +12,7 @@ package it.unibo.alchemist.boundary.graphql.schema.operations.queries
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.server.operations.Query
 import it.unibo.alchemist.boundary.graphql.schema.model.surrogates.toGraphQLEnvironmentSurrogate
+import it.unibo.alchemist.boundary.graphql.schema.model.surrogates.toGraphQLSimulationSurrogate
 import it.unibo.alchemist.model.Environment
 import it.unibo.alchemist.model.Position
 
@@ -23,14 +24,13 @@ import it.unibo.alchemist.model.Position
 class EnvironmentQueries<T, P : Position<out P>>(private val environment: Environment<T, P>) : Query {
 
     /**
+     * Returns the actual state of the simulation.
+     */
+    fun simulation() = environment.simulation.toGraphQLSimulationSurrogate()
+
+    /**
      * Returns the actual state of the environment.
      */
     @GraphQLDescription("The actual state of the environment")
     fun environment() = this.environment.toGraphQLEnvironmentSurrogate()
-
-    /**
-     * Returns the status of the simulation.
-     */
-    @GraphQLDescription("The status of the simulation")
-    fun simulationStatus() = this.environment.simulation.status.toString()
 }

--- a/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/queries/NodeQueries.kt
+++ b/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/queries/NodeQueries.kt
@@ -21,7 +21,7 @@ import it.unibo.alchemist.model.Position
 /**
  * Set of GraphQL queries to compute on nodes.
  */
-class NodeQueries<T, P : Position<out P>>(private val environment: Environment<T, P>) : Query {
+class NodeQueries<T, P : Position<out P>>(environment: Environment<T, P>) : Query {
 
     private val environmentSurrogate: EnvironmentSurrogate<T, P> = environment.toGraphQLEnvironmentSurrogate()
 

--- a/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/subscriptions/EnvironmentSubscriptions.kt
+++ b/alchemist-graphql-surrogates/src/main/kotlin/it/unibo/alchemist/boundary/graphql/schema/operations/subscriptions/EnvironmentSubscriptions.kt
@@ -12,10 +12,13 @@ package it.unibo.alchemist.boundary.graphql.schema.operations.subscriptions
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.server.operations.Subscription
 import it.unibo.alchemist.boundary.graphql.schema.model.surrogates.EnvironmentSurrogate
+import it.unibo.alchemist.boundary.graphql.schema.model.surrogates.SimulationSurrogate
+import it.unibo.alchemist.boundary.graphql.schema.model.surrogates.toGraphQLSimulationSurrogate
 import it.unibo.alchemist.model.Environment
 import it.unibo.alchemist.model.Position
 import it.unibo.alchemist.model.util.Environments.subscriptionMonitor
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 /**
  * Exposes alchemist [it.unibo.alchemist.model.Environment] as a GraphQL subscription
@@ -24,6 +27,15 @@ import kotlinx.coroutines.flow.Flow
 class EnvironmentSubscriptions<T, P : Position<out P>>(environment: Environment<T, P>) : Subscription {
 
     private val environmentMonitor = environment.subscriptionMonitor()
+
+    /**
+     * Returns a [Flow] with the updated value of the
+     * [it.unibo.alchemist.boundary.graphql.schema.model.surrogates.SimulationSurrogate].
+     */
+    @GraphQLDescription("The simulation")
+    fun simulation(): Flow<SimulationSurrogate<T, P>> = environmentMonitor.eventFlow.map { env ->
+        env.origin.simulation.toGraphQLSimulationSurrogate()
+    }
 
     /**
      * Returns a [Flow] with the updated value of the

--- a/alchemist-graphql/build.gradle.kts
+++ b/alchemist-graphql/build.gradle.kts
@@ -22,11 +22,10 @@ plugins {
 }
 
 kotlin {
-    jvm()
+    jvm { withJava() }
     js(IR) {
-        browser {
-            binaries.executable()
-        }
+        browser()
+        binaries.executable()
     }
     sourceSets {
         val commonMain by getting {

--- a/alchemist-graphql/src/commonMain/kotlin/it/unibo/alchemist/boundary/graphql/client/GraphQLClient.kt
+++ b/alchemist-graphql/src/commonMain/kotlin/it/unibo/alchemist/boundary/graphql/client/GraphQLClient.kt
@@ -20,6 +20,26 @@ import com.apollographql.apollo3.api.Subscription
 interface GraphQLClient {
 
     /**
+     * The address of the GraphQL server.
+     */
+    val host: String
+
+    /**
+     * The port of the GraphQL server.
+     */
+    val port: Int
+
+    /**
+     * The URL of the GraphQL server.
+     */
+    fun serverUrl(): String = "http://$host:$port/graphql"
+
+    /**
+     * The URL of the GraphQL server subscription.
+     */
+    fun subscriptionUrl(): String
+
+    /**
      * Prepare a query to be executed.
      * @param query the query to be executed
      * @return the associated [ApolloCall] that can be executed

--- a/alchemist-graphql/src/commonMain/kotlin/it/unibo/alchemist/boundary/graphql/client/SimulationHandler.kt
+++ b/alchemist-graphql/src/commonMain/kotlin/it/unibo/alchemist/boundary/graphql/client/SimulationHandler.kt
@@ -49,7 +49,7 @@ class SimulationHandler(private val graphqlClient: GraphQLClient) {
     /**
      * Returns the status of the simulation.
      */
-    suspend fun status() = graphqlClient.query(SimulationStatusQuery()).execute().data?.simulationStatus
+    suspend fun status() = graphqlClient.query(SimulationStatusQuery()).execute().data?.simulation?.status
 
     private suspend fun handleSimulation(action: Mutation<*>) =
         graphqlClient.mutation(action).execute().data!!

--- a/alchemist-graphql/src/commonMain/resources/graphql/ConcentrationSubscription.graphql
+++ b/alchemist-graphql/src/commonMain/resources/graphql/ConcentrationSubscription.graphql
@@ -1,0 +1,10 @@
+subscription ConcentrationSubscription($moleculeName : String! ) {
+    simulation {
+        time
+        environment {
+            nodes{
+              getConcentration(molecule: { name: $moleculeName } )
+            }
+        }
+    }
+}

--- a/alchemist-graphql/src/commonMain/resources/graphql/NodesSubscription.graphql
+++ b/alchemist-graphql/src/commonMain/resources/graphql/NodesSubscription.graphql
@@ -1,0 +1,18 @@
+subscription NodesSubscription {
+    simulation {
+        status
+        time
+        environment {
+            nodes {
+                contents {
+                    entries {
+                        molecule {
+                            name
+                        }
+                        concentration
+                    }
+                }
+            }
+        }
+    }
+}

--- a/alchemist-graphql/src/commonMain/resources/graphql/SimulationStatus.graphql
+++ b/alchemist-graphql/src/commonMain/resources/graphql/SimulationStatus.graphql
@@ -1,3 +1,5 @@
 query SimulationStatus {
-    simulationStatus
+    simulation {
+        status
+    }
 }

--- a/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/graphql/server/modules/GraphQLModule.kt
+++ b/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/graphql/server/modules/GraphQLModule.kt
@@ -12,6 +12,7 @@ package it.unibo.alchemist.boundary.graphql.server.modules
 import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
 import com.expediagroup.graphql.server.ktor.DefaultKtorGraphQLContextFactory
 import com.expediagroup.graphql.server.ktor.GraphQL
+import io.ktor.http.HttpMethod
 import io.ktor.serialization.jackson.JacksonWebsocketContentConverter
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -19,25 +20,26 @@ import io.ktor.server.plugins.compression.Compression
 import io.ktor.server.plugins.compression.gzip
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.websocket.WebSockets
-import io.ktor.server.websocket.pingPeriod
-import io.ktor.server.websocket.timeout
 import it.unibo.alchemist.boundary.graphql.schema.operations.mutations.SimulationControl
 import it.unibo.alchemist.boundary.graphql.schema.operations.queries.EnvironmentQueries
 import it.unibo.alchemist.boundary.graphql.schema.operations.queries.NodeQueries
 import it.unibo.alchemist.boundary.graphql.schema.operations.subscriptions.EnvironmentSubscriptions
 import it.unibo.alchemist.boundary.graphql.schema.operations.subscriptions.NodeSubscriptions
 import it.unibo.alchemist.model.Environment
-import java.time.Duration
-
-// The following values are referred to milliseconds.
-private const val DEFAULT_PING_PERIOD = 1000L
-private const val DEFAULT_TIMEOUT_DURATION = 10000L
 
 /**
  * Ktor module for enabling GraphQL on server.
  */
 fun Application.graphQLModule(environment: Environment<*, *>) {
     install(CORS) {
+        HttpMethod.DefaultMethods.forEach {
+            allowMethod(it)
+        }
+        allowOrigins { true }
+        allowNonSimpleContentTypes = true
+        allowCredentials = true
+        allowSameOrigin = true
+        allowHost("*", listOf("http", "https"))
         anyHost()
     }
 
@@ -46,8 +48,6 @@ fun Application.graphQLModule(environment: Environment<*, *>) {
     }
 
     install(WebSockets) {
-        pingPeriod = Duration.ofMillis(DEFAULT_PING_PERIOD)
-        timeout = Duration.ofMillis(DEFAULT_TIMEOUT_DURATION)
         maxFrameSize = Long.MAX_VALUE
         masking = false
         contentConverter = JacksonWebsocketContentConverter()

--- a/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/monitors/GraphQLMonitor.kt
+++ b/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/monitors/GraphQLMonitor.kt
@@ -11,7 +11,6 @@ package it.unibo.alchemist.boundary.launchers
 
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
-import io.ktor.server.engine.stop
 import io.ktor.server.netty.Netty
 import it.unibo.alchemist.boundary.OutputMonitor
 import it.unibo.alchemist.boundary.graphql.monitor.EnvironmentSubscriptionMonitor
@@ -25,7 +24,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Semaphore
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(GraphQLMonitor::class.java)
 
 /**
  * An [OutputMonitor] observing the [environment] through a GraphQL server listening on [host]:[port].
@@ -33,7 +34,7 @@ import kotlinx.coroutines.sync.Semaphore
  * By default, the server is stopped after the simulation terminates.
  * This behavior can be changed by setting [teardownOnSimulationTermination] to false.
  */
-class GraphQLServer<T, P : Position<out P>> @JvmOverloads constructor(
+class GraphQLMonitor<T, P : Position<out P>> @JvmOverloads constructor(
     val environment: Environment<T, P>,
     val host: String = DefaultGraphQLSettings.DEFAULT_HOST,
     val port: Int = DefaultGraphQLSettings.DEFAULT_PORT,
@@ -59,6 +60,9 @@ class GraphQLServer<T, P : Position<out P>> @JvmOverloads constructor(
             },
             "alchemist-graphql-server@$host:$port",
         ).start()
+        runBlocking {
+            logger.info("Starting GraphQL server at $host:${server.resolvedConnectors().first().port}")
+        }
         mutex.acquireUninterruptibly()
     }
 
@@ -74,7 +78,7 @@ class GraphQLServer<T, P : Position<out P>> @JvmOverloads constructor(
             port = port,
             host = host,
             module = {
-                graphQLModule(this@GraphQLServer.environment)
+                graphQLModule(this@GraphQLMonitor.environment)
                 graphQLRoutingModule()
             },
         )

--- a/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/monitors/GraphQLMonitor.kt
+++ b/alchemist-graphql/src/jvmMain/kotlin/it/unibo/alchemist/boundary/monitors/GraphQLMonitor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2023, Danilo Pianini and contributors
+ * Copyright (C) 2010-2024, Danilo Pianini and contributors
  * listed, for each module, in the respective subproject's build.gradle.kts file.
  *
  * This file is part of Alchemist, and is distributed under the terms of the
@@ -7,7 +7,7 @@
  * as described in the file LICENSE in the Alchemist distribution's top directory.
  */
 
-package it.unibo.alchemist.boundary.launchers
+package it.unibo.alchemist.boundary.monitors
 
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer

--- a/alchemist-graphql/src/jvmTest/kotlin/it/unibo/alchemist/boundary/GraphQLTestEnvironments.kt
+++ b/alchemist-graphql/src/jvmTest/kotlin/it/unibo/alchemist/boundary/GraphQLTestEnvironments.kt
@@ -10,7 +10,7 @@
 package it.unibo.alchemist.boundary
 
 import it.unibo.alchemist.boundary.graphql.monitor.EnvironmentSubscriptionMonitor
-import it.unibo.alchemist.boundary.launchers.GraphQLServer
+import it.unibo.alchemist.boundary.monitors.GraphQLMonitor
 import it.unibo.alchemist.model.Environment
 import it.unibo.alchemist.model.Position
 import it.unibo.alchemist.util.ClassPathScanner
@@ -22,7 +22,7 @@ object GraphQLTestEnvironments {
             .map { LoadAlchemist.from(it) }
             .map { it.getDefault<T, P>() }
             .forEach { simulation ->
-                simulation.outputMonitors.find { it is GraphQLServer<*, *> }
+                simulation.outputMonitors.find { it is GraphQLMonitor<*, *> }
                 simulation.outputMonitors.find { it is EnvironmentSubscriptionMonitor<*, *> }
                 test(simulation.environment)
             }

--- a/alchemist-graphql/src/jvmTest/resources/it/unibo/alchemist/test/graphql/sapere.yml
+++ b/alchemist-graphql/src/jvmTest/resources/it/unibo/alchemist/test/graphql/sapere.yml
@@ -14,7 +14,7 @@ launcher:
     autostart: false
 
 monitors:
-  type: GraphQLServer
+  type: GraphQLMonitor
 
 network-model:
   type: ConnectWithinDistance

--- a/site/content/howtos/development/graphql/_index.md
+++ b/site/content/howtos/development/graphql/_index.md
@@ -1,0 +1,69 @@
++++
+pre = ""
+title = "Enrich the GraphQL API"
+weight = 10
+tags = ["graphql", "query", "subscription"]
+summary = "How to create a new Query, Subscription, or Mutation using the GraphQL API"
++++
+
+It is possible to integrate new queries, mutations, or subscriptions into the GraphQL API.
+This augmentation offers a more organized and anticipatable approach for interacting with the simulator,
+thanks to the strong typing and the schema definition.
+
+It is possible to use GraphQL APIs for the development of a module inside
+Alchemist.
+The `GraphQLClient` class will  take care of establishing a connection
+to the GraphQL server, validate and compute operations and give back their results.
+This component has been  developed in a multiplatform environment, so that applications
+can lay on platforms like Android, iOS, Kotlin/JS or Kotlin/Native.
+
+#### Create a new Query, Mutation, or Subscription
+In order to create new queries, mutations, or subscriptions, follow these steps:
+
+1. Include the `alchemist-graphql` common source set in your project.
+```kotlin
+implementation(alchemist("graphql"))
+```
+
+2. Define the structure of the data you need when executing one of the provided
+   operations, inside a set of files with `.graphql` extension placed in the
+   `alchemist-graphql/src/commonMain/resources/graphql/` directory.
+    The following is an example of a query that retrieves the contents of a node
+    by its ID:
+```graphql
+# NodeQuery.graphql
+query Node($id: Int!) {
+    nodeById(id: $id) {
+        contents {
+            entries {
+                molecule {
+                    name
+                }
+                concentration
+            }
+        }
+    }
+}
+```
+
+{{% notice tip "Use GraphiQL to build client's operations files" %}}
+You can test the structure of the data that you need inside the GraphiQL
+playground, in order to get predicable results when compiling your operations.
+GraphiQL also notices you if you are writing incorrect operations with useful
+explanation about the errors.
+{{% /notice %}}
+
+3. Run the Gradle task `./gradlew
+   :alchemist-graphql:generateApolloSources` in order to
+   generate Kotlin's source code that represents the results of operations
+   called in previously defined files.
+
+4. Use the defined GraphQL compiled operations on top of the `GraphQLClient`
+   to execute them.
+
+```kotlin
+val client: GraphQLClient = GraphQLClientFactory.basicClient()
+/* `NodeQuery` is the generated code for the
+    GraphQL operation defined in the example above */
+val node: Node? = client.query(NodeQuery(nodeId = 10)).execute().data
+```

--- a/site/content/howtos/development/graphql/_index.md
+++ b/site/content/howtos/development/graphql/_index.md
@@ -7,15 +7,15 @@ summary = "How to create a new Query, Subscription, or Mutation using the GraphQ
 +++
 
 It is possible to integrate new queries, mutations, or subscriptions into the GraphQL API.
-This augmentation offers a more organized and anticipatable approach for interacting with the simulator,
-thanks to the strong typing and the schema definition.
+This augmentation offers a more organized and predictable approach for interacting with the simulator,
+thanks to static typing and schema definition.
 
 It is possible to use GraphQL APIs for the development of a module inside
 Alchemist.
 The `GraphQLClient` class will  take care of establishing a connection
-to the GraphQL server, validate and compute operations and give back their results.
+to the GraphQL server, validate and compute operations and return their results.
 This component has been  developed in a multiplatform environment, so that applications
-can lay on platforms like Android, iOS, Kotlin/JS or Kotlin/Native.
+can run on platforms like Android, iOS, Kotlin/JS or Kotlin/Native.
 
 #### Create a new Query, Mutation, or Subscription
 In order to create new queries, mutations, or subscriptions, follow these steps:
@@ -67,3 +67,4 @@ val client: GraphQLClient = GraphQLClientFactory.basicClient()
     GraphQL operation defined in the example above */
 val node: Node? = client.query(NodeQuery(nodeId = 10)).execute().data
 ```
+

--- a/site/content/howtos/simulation/graphql/_index.md
+++ b/site/content/howtos/simulation/graphql/_index.md
@@ -15,22 +15,17 @@ simulation, or to develop an Alchemist sub-module that uses the API service.
 
 ## Using GraphQL service inside Alchemist
 In order to attach the GraphQL API service to a simulation, you must specify
-the `GraphQLSimulationLauncher` in the simulation's YAML file, providing the
+the `GraphQLMonitor` in the simulation's YAML file, providing the
 server's host and port (if not specified, default URL is: `127.0.0.1:8081`) as
 shown in the following example:
 ```yml
-launcher:
-  type: GraphQLServerLauncher
+monitors:
+  type: GraphQLMonitor
   parameters:
     host: <my-custom-host>
     port: <my-custom-port>
 ```
 Once the YAML file is ready, the simulation can be started as usual.
-
-{{% notice warning %}}
-Note: At the current state, only one simulation at a time can be launched through the
-GraphQL simulation launcher.
-{{% /notice %}}
 
 ### Simulation's overview in the Web Browser
 Once the simulation is up and running, you can visit on your local web browser
@@ -79,7 +74,7 @@ explanation about the errors.
 {{% /notice %}}
 
 3. Run the Gradle task `./gradlew
-   :alchemist-graphql:generateAlchemist-graphqlApolloSources` in order to
+   :alchemist-graphql:generateApolloSources` in order to
    generate Kotlin's source code that represents the results of operations
    called in previously defined files.
 

--- a/site/content/howtos/simulation/graphql/_index.md
+++ b/site/content/howtos/simulation/graphql/_index.md
@@ -13,7 +13,7 @@ simple overview of the running simulation thanks to the playground
 [GraphiQL](https://github.com/graphql/graphiql) with the ability to control the
 simulation, or to develop an Alchemist sub-module that uses the API service.
 
-## Using GraphQL service inside Alchemist
+## Use GraphQL service inside Alchemist
 In order to attach the GraphQL API service to a simulation, you must specify
 the `GraphQLMonitor` in the simulation's YAML file, providing the
 server's host and port (if not specified, default URL is: `127.0.0.1:8081`) as
@@ -34,56 +34,3 @@ playground you will be able to lookup all the operations and types structure
 that are defined in the GraphQL schema, thanks to the documentation on the
 sidebar, or execute operations defining the structure of the data that you will
 need.
-
-### Using GraphQL APIs inside the JVM
-If you plan to use GraphQL APIs for the development of a module inside
-Alchemist, you can do so by using the provided `GraphQLClient`. This class will
-take care of establishing a connection to the GraphQL server, validate and
-compute operations and give back their results. This component has been
-developed in a multiplatform environment, so that applications can lay on
-platforms like Android, iOS, Kotlin/JS or Kotlin/Native.
-
-In order to use the GraphQL API service, refer to the following steps:
-
-1. Include the `alchemist-graphql` common source set in your project.
-
-2. Define the structure of the data you need when executing one of the provided
-   operations, inside a set of files with `.graphql` extension placed in the
-   `alchemist-graphql/src/commonMain/resources/graphql/` directory.
-```graphql
-# NodeQuery.graphql
-query Node($id: Int!) {
-    nodeById(id: $id) {
-        contents {
-            entries {
-                molecule {
-                    name
-                }
-                concentration
-            }
-        }
-    }
-}
-```
-
-{{% notice tip "Use GraphiQL to build client's operations files" %}}
-You can test the structure of the data that you need inside the GraphiQL
-playground, in order to get predicable results when compiling your operations.
-GraphiQL also notices you if you are writing incorrect operations with useful
-explanation about the errors.
-{{% /notice %}}
-
-3. Run the Gradle task `./gradlew
-   :alchemist-graphql:generateApolloSources` in order to
-   generate Kotlin's source code that represents the results of operations
-   called in previously defined files.
-
-4. Use the defined GraphQL compiled operations on top of the `GraphQLClient`
-    to execute them.
-
-```kotlin
-val client: GraphQLClient = GraphQLClientFactory.basicClient()
-/* `NodeQuery` is the generated code for the
-    GraphQL operation defined in the example above */
-val node: Node? = client.query(NodeQuery(nodeId = 10)).execute().data
-```


### PR DESCRIPTION
**This is a BREAKING CHANGE since i changed the name of the GraphQLServer (which was an Output Monitor) to GraphQLMonitor**

This PR introduce simpler ways to obtain data using subscriptions in GraphQL.
By creating a `SimulationSurrogate` it is possible to obtain data related to the simulation also using subscriptions and not only using queries.

Please note, this means that it is now possible to do so:

```graphql
subscription Example {
  simulation {
    time
    status
    environment {
      ... other stuff
    }
  }
}
```

however, the following syntax is also valid as a simplification (by omitting the simulation block):

```graphql
subscription Example {
  environment {
    ... other stuff
  }
}
```

If you want the simulation block to always be present I can do that. Personally I like it this way since it allows more customization in shaping the request and the  response.