### PR TITLE
build(web-renderer): remove useless spotbugs lib in kotlin/js project

### DIFF
--- a/alchemist-web-renderer/build.gradle.kts
+++ b/alchemist-web-renderer/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                compileOnly(libs.spotbugs.annotations)
                 implementation(libs.korim)
                 implementation(libs.kotlin.stdlib)
                 implementation(libs.kotlinx.serialization.json)


### PR DESCRIPTION
This PR will solve the following problem.
It was caused by the spotbugs lib, which was incorrectly imported in a Kotlin/JS project using `compileOnly`.
Spotbugs is already correctly configured in the root `build.gradle.kts` so I simply removed it in the specific project.

```
2024-09-02T15:14:29.9352380Z w: A compileOnly dependency is used in targets: Kotlin/JS.
2024-09-02T15:14:29.9353297Z Dependencies:
2024-09-02T15:14:29.9354327Z     - com.github.spotbugs:spotbugs-annotations:4.8.6 (source sets: jsMain)
2024-09-02T15:14:29.9355207Z 
2024-09-02T15:14:29.9356738Z Using compileOnly dependencies in these targets is not currently supported, because compileOnly dependencies must be present during the compilation of projects that depend on this project.
2024-09-02T15:14:29.9358471Z 
2024-09-02T15:14:29.9359381Z To ensure consistent compilation behaviour, compileOnly dependencies should be exposed as api dependencies.
2024-09-02T15:14:29.9360526Z 
2024-09-02T15:14:29.9360832Z Example:
2024-09-02T15:14:29.9361217Z 
2024-09-02T15:14:29.9361518Z     kotlin {
2024-09-02T15:14:29.9362123Z         sourceSets {
2024-09-02T15:14:29.9362778Z             nativeMain {
2024-09-02T15:14:29.9363468Z                 dependencies {
2024-09-02T15:14:29.9364758Z                     compileOnly("org.example:lib:1.2.3")
2024-09-02T15:14:29.9365887Z                     // additionally add the compileOnly dependency as an api dependency:
2024-09-02T15:14:29.9367254Z                     api("org.example:lib:1.2.3")
2024-09-02T15:14:29.9368099Z                 }
2024-09-02T15:14:29.9368697Z             }
2024-09-02T15:14:29.9369281Z         }
2024-09-02T15:14:29.9369821Z     }
2024-09-02T15:14:29.9370184Z 
2024-09-02T15:14:29.9370648Z This warning can be suppressed in gradle.properties:
2024-09-02T15:14:29.9371337Z 
2024-09-02T15:14:29.9372029Z     kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
```
