### PR TITLE
fix(graphql): missing dependency for generated tests

### DIFF
--- a/alchemist-graphql/build.gradle.kts
+++ b/alchemist-graphql/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
+                implementation(libs.graphql.client)
                 implementation(libs.kotest.assertions.core)
                 implementation(libs.kotest.runner)
                 implementation(libs.ktor.server.test.host)
@@ -92,10 +93,6 @@ tasks.withType<AbstractGenerateClientTask>().configureEach {
             queryFileDirectory.set(file("src/commonMain/resources/graphql"))
         }
     }
-}
-
-tasks.graphqlGenerateTestClient.configure {
-    enabled = false // TODO: investigate why this breaks the build
 }
 
 val surrogates = project(":${project.name}-surrogates")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ dyn4j = "org.dyn4j:dyn4j:5.0.2"
 dsiutils = "it.unimi.dsi:dsiutils:2.7.3"
 embedmongo = "de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.18.1"
 graphhopper-core = { module = "com.graphhopper:graphhopper-core", version.ref = "graphhopper" }
+graphql-client = { module = "com.expediagroup:graphql-kotlin-client", version.ref = "graphql" }
 graphql-hooks-provider = { module = "com.expediagroup:graphql-kotlin-hooks-provider", version.ref = "graphql" }
 graphql-server = { module = "com.expediagroup:graphql-kotlin-server", version.ref = "graphql" }
 graphql-server-ktor = { module = "com.expediagroup:graphql-kotlin-ktor-server", version.ref = "graphql" }


### PR DESCRIPTION
@DanySK can sleep peacefully (maybe).

Generated GrapqhQL tests relies on the Graphql client dependency for some annotation and other misc functionalities.

Let's see if this works.