### PR TITLE
build(alchemist-incarnation-scafi)!: set as `api` scafi dependency

### DIFF
--- a/alchemist-incarnation-scafi/build.gradle.kts
+++ b/alchemist-incarnation-scafi/build.gradle.kts
@@ -24,11 +24,12 @@ plugins {
 dependencies {
     compileOnly(libs.spotbugs.annotations)
 
+    api(libs.scafi.core)
+
     implementation(alchemist("api"))
     implementation(alchemist("euclidean-geometry"))
     implementation(alchemist("implementationbase"))
     implementation(alchemist("physics"))
-    api(libs.scafi.core)
     implementation(libs.resourceloader)
     implementation(libs.bundles.scala)
     implementation(libs.bundles.scalacache)

--- a/alchemist-incarnation-scafi/build.gradle.kts
+++ b/alchemist-incarnation-scafi/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(alchemist("euclidean-geometry"))
     implementation(alchemist("implementationbase"))
     implementation(alchemist("physics"))
-    implementation(libs.scafi.core)
+    api(libs.scafi.core)
     implementation(libs.resourceloader)
     implementation(libs.bundles.scala)
     implementation(libs.bundles.scalacache)


### PR DESCRIPTION
It is more convenient to make the `scafi` dependency available as a project `api`.
What do you think? Is there a stronger reason to make it `implementation`, and not `api`?